### PR TITLE
OpTestConfiguration: Add Multihost support for op-test

### DIFF
--- a/testcases/OpTestMultiHost.py
+++ b/testcases/OpTestMultiHost.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2018
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+
+import unittest
+
+import OpTestConfiguration
+from common.OpTestSystem import OpSystemState
+
+
+class OpTestMultiHost(unittest.TestCase):
+    def setUp(self):
+        self.conf = OpTestConfiguration.conf
+        # retrieve the multi hosts objects
+        self.hosts = self.conf.get_all_hosts()
+
+    def runTest(self):
+        for host in self.hosts:
+            self.cv_SYSTEM = host.system()
+            self.cv_SYSTEM.goto_state(OpSystemState.OS)
+            con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
+            con.run_command("hostname -f", timeout=60)


### PR DESCRIPTION
    `def get_all_hosts()` can be used to get list of host objects that
    can be used to perform operations on that specific host.
    The changes doesn't affect the current implementation, it extends
    the multihost functionality with `class MultiHost()` by having
    host specific configurations associated with respective host object.
    
    The input for different hosts are given in optest configuration file
    `~/.op-test-framework.conf` with config items like,
    
    [op-test]
    # primary host machine that uses by default
    bmc_type=SMC
    bmc_ip=10.1.1.2
    bmc_username=USERNAME
    bmc_password=PASSWORD
    bmc_usernameipmi=USERNAME
    bmc_passwordipmi=PASSWORD
    host_ip=10.1.1.3
    host_user=root
    host_password=password
    
    1st secondary host machine
    [host1] # host1 specific config item
    bmc_type=FSP
    bmc_ip=10.1.1.5
    bmc_username=USERNAME
    bmc_password=PASSWORD
    bmc_passwordipmi=PASSWORD
    host_ip=10.1.1.4
    host_user=root
    host_password=password
    
    2nd secondary host machine
    [host2] # host2 specific config item
    bmc_type=AMC
    bmc_ip=10.1.1.5
    bmc_username=USERNAME
    bmc_password=PASSWORD
    bmc_passwordipmi=PASSWORD
    host_ip=10.1.1.4
    host_user=root
    host_password=password
    
    No of secondary host machines to be used can be given using `--multi-hosts` argument
    or specific host machines can be given using `--multi-hosts-name`
    
    Example:
    ./op-test --multi-hosts 2 <other args>
    
    or
    
    ./op-test --multi-hosts-name "host1,host2" <other args>
    
    Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>
