### PR TITLE
OpTestModel: Add OpCheck class and OpTestModel testcase

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -408,6 +408,10 @@ def get_parser():
         "--lpar-prof", help="Lpar profile provided in HMC", default=None)
     hmcgroup.add_argument(
         "--lpar-vios", help="Lpar VIOS to boot before other LPARS", default=None)
+    tunables = parser.add_argument_group('Tunables',
+                                         'Advanced Customizable attributes')
+    tunables.add_argument("--check-up", action='store_true', default=False,
+                         help="Switch for getting more debug on possible health checks, this may alter your exit code")
 
     return parser
 
@@ -423,6 +427,8 @@ class OpTestConfiguration():
         self.basedir = os.path.dirname(sys.argv[0])
         self.signal_ready = False  # indicator for properly initialized
         self.atexit_ready = False  # indicator for properly initialized
+        self.needs_checked = True # state to run search_debug once, if args check_up=True
+        self.check_up_issues = None # flag to investigate, if args check_up=True
         self.aes_print_helpers = True  # Need state for locker_wait
         self.dump = True  # Need state for cleanup
         self.lock_dict = {'res_id': None,

--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -28,14 +28,26 @@
 OpTestConstants
 ---------------
 
-BMC package which contains all BMC related constants
+Package which contains OpTest related constants for OpenPower systems
 
-This class encapsulates commands and constants which deals with the BMC in
-OpenPower systems
 '''
 
 import pexpect
 
+class OpConstants():
+    '''
+    This class is used as an enum as to what state op-test *thinks* the host is in.
+    These states are used to drive a state machine in OpTestSystem.
+    '''
+    UNKNOWN = 0
+    OFF = 1
+    IPLing = 2
+    PETITBOOT = 3
+    PETITBOOT_SHELL = 4
+    BOOTING = 5
+    OS = 6
+    POWERING_OFF = 7
+    UNKNOWN_BAD = 8 # special case, use set_state to place system in hold for later goto
 
 class OpTestConstants():
 

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -48,7 +48,7 @@ import subprocess
 import OpTestConfiguration
 from .OpTestConstants import OpTestConstants as BMC_CONST
 from .OpTestError import OpTestError
-from .OpTestSSH import OpTestSSH
+from . import OpTestSSH # circular dependencies, use package
 from . import OpTestQemu
 from .Exceptions import CommandFailed, NoKernelConfig, KernelModuleNotLoaded, KernelConfigNotSet, ParameterCheck
 
@@ -75,7 +75,7 @@ class OpTestHost():
         self.bmcip = i_bmcip
         self.results_dir = i_results_dir
         self.logfile = logfile
-        self.ssh = OpTestSSH(i_hostip, i_hostuser, i_hostpasswd,
+        self.ssh = OpTestSSH.OpTestSSH(i_hostip, i_hostuser, i_hostpasswd,
                              logfile=self.logfile, check_ssh_keys=check_ssh_keys,
                              known_hosts_file=known_hosts_file)
         self.scratch_disk = scratch_disk

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -43,9 +43,9 @@ import sys
 import re
 
 from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestConstants import OpConstants as OpSystemState
 from .OpTestError import OpTestError
 from .OpTestUtil import OpTestUtil
-from . import OpTestSystem
 from .Exceptions import CommandFailed
 from .Exceptions import BMCDisconnected
 from . import OPexpect
@@ -94,7 +94,7 @@ class IPMITool():
             cmd = cmdprefix + self.binary + self.arguments() + cmd
         else:
             cmd = self.binary + self.arguments() + cmd
-        log.debug(cmd)
+        log.debug("ipmitool cmd={}".format(cmd))
         if background:
             try:
                 child = subprocess.Popen(
@@ -179,7 +179,7 @@ class IPMIConsoleState():
 
 def set_system_to_UNKNOWN_BAD(system):
     s = system.get_state()
-    system.set_state(OpTestSystem.OpSystemState.UNKNOWN_BAD)
+    system.set_state(OpSystemState.UNKNOWN_BAD)
     return s
 
 
@@ -653,16 +653,19 @@ class OpTestIPMI():
         output = self.ipmitool.run('sel elist')
 
         if dump:
-            print(
-                "\n----------------------------------------------------------------------")
-            print("SELs")
-            print(
-                "----------------------------------------------------------------------")
-            print(("{}".format(output)))
-            print(
-                "----------------------------------------------------------------------")
+            output_list = []
+            output_list.append("\n----------------------------------------------------------------------")
+            output_list.append("SELs")
+            output_list.append("----------------------------------------------------------------------")
+            for line in output.splitlines():
+                output_list.append("{}".format(line))
+            output_list.append("----------------------------------------------------------------------")
 
-        return output
+            for line in output_list:
+                self.logfile.write("{}\n".format(line))
+            self.logfile.flush()
+
+        return output.splitlines()
 
     def ipmi_power_status(self):
         '''

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -34,7 +34,7 @@ import time
 from .Exceptions import CommandFailed, UnexpectedCase
 import OpTestConfiguration
 
-from common.OpTestSystem import OpSystemState
+from .OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -33,6 +33,8 @@ from .OpTestBMC import OpTestBMC
 from .Exceptions import HTTPCheck
 from .Exceptions import CommandFailed
 from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestUtil import build_esel
+from .OpTestUtil import print_dump
 from . import OpTestSystem
 
 import logging
@@ -240,40 +242,14 @@ class HostManagement():
                     dict_item['Procedure'] = str(add_data[i].split('=')[1])
             dict_list.append(dict_item)
 
+        esel, output = build_esel(id_list=id_list,
+                                  dict_list=dict_list,
+                                 )
+
+        # this will go to op-test logfile
         if dump:
-            print(
-                "\n----------------------------------------------------------------------")
-            print("SELs")
-            print(
-                "----------------------------------------------------------------------")
-            if len(id_list) == 0:
-                print("SEL has no entries")
-            for k in dict_list:
-                print(("Id          : {}".format(k.get('Id'))))
-                print(("Message     : {}".format(k.get('Message'))))
-                print(("Description : {}".format(k.get('Description'))))
-                print(("Timestamp   : {}".format(k.get('Timestamp'))))
-                print(("Severity    : {}".format(k.get('Severity'))))
-                print(("Resolved    : {}".format(k.get('Resolved'))))
-                if k.get('EventID') is not None:
-                    print(("EventID     : {}".format(k.get('EventID'))))
-                if k.get('Procedure') is not None:
-                    print(("Procedure   : {}".format(k.get('Procedure'))))
-                if k.get('esel') is not None:
-                    print(("ESEL        : characters={}\n".format(
-                        len(k.get('esel')))))
-                    print(
-                        "Ruler        : 0123456789012345678901234567890123456789012345678901234567890123")
-                    print(
-                        "-------------------------------------------------------------------------------")
-                    for j in range(0, len(k.get('esel')), 64):
-                        print(("{:06d}-{:06d}: {}".format(j,
-                                                          j+63, k.get('esel')[j:j+64])))
-                else:
-                    print("ESEL        : None")
-                print("\n")
-            print(
-                "----------------------------------------------------------------------")
+            print_dump(conf=self.conf, list_obj=output)
+
         # sample id_list ['81', '82', '83', '84']
         log.debug("id_list={}".format(id_list))
         log.debug("dict_list={}".format(dict_list))

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -20,6 +20,7 @@
 from . import OpTestSystem
 from .OpTestUtil import OpTestUtil
 from .Exceptions import CommandFailed, SSHSessionDisconnected
+from .OpTestConstants import OpConstants as OpSystemState
 import re
 import sys
 import os
@@ -46,7 +47,7 @@ class ConsoleState():
 
 def set_system_to_UNKNOWN_BAD(system):
     s = system.get_state()
-    system.set_state(OpTestSystem.OpSystemState.UNKNOWN_BAD)
+    system.set_state(OpSystemState.UNKNOWN_BAD)
     return s
 
 

--- a/common/OpTestThread.py
+++ b/common/OpTestThread.py
@@ -35,6 +35,7 @@ import pexpect
 import OpTestConfiguration
 from .OpTestSystem import OpSystemState
 from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestConstants import OpConstants as OpSystemState
 from .Exceptions import CommandFailed
 from .OpTestIPMI import IPMIConsoleState
 

--- a/op-test
+++ b/op-test
@@ -102,6 +102,7 @@ from testcases import OpTestSensors
 from testcases import OpTestSwitchEndianSyscall
 from testcases import OpTestHostboot
 from testcases import OpTestExample
+from testcases import OpTestModel
 import OpTestConfiguration
 import sys
 import time
@@ -137,7 +138,6 @@ def optest_handler(signum, frame):
     # to the stack frame executing at the time the signal is received
     # by the python interpreter, if the exception was caught during some other
     # try/except block, control will be given back to that block
-
 
 signal.signal(signal.SIGHUP, optest_handler)
 signal.signal(signal.SIGINT, optest_handler)
@@ -187,6 +187,7 @@ class SkirootSuite():
 #        self.s.addTest(DeviceTreeWarnings.Skiroot())
         self.s.addTest(unittest.TestLoader(
         ).loadTestsFromTestCase(IplParams.Skiroot))
+#        self.s.addTest(OpTestModel.skiroot_model_suite())
         # disabling temporarily
 #        self.s.addTest(SecureBoot.VerifyOPALSecureboot())
         self.s.addTest(TrustedBoot.VerifyOPALTrustedBoot())
@@ -213,7 +214,7 @@ class SkirootSuite():
         # disabling OpalMsglog temporarily
 #        self.s.addTest(OpalMsglog.Skiroot())
         # disabling KernelLog temporarily
-#        self.s.addTest(KernelLog.Skiroot())
+#        self.s.addTest(KernelLog.skiroot_klog_suite())
         self.s.addTest(gcov.Skiroot())
         self.s.addTest(DPO.DPOSkiroot())
 #        self.s.addTest(OpTestEnergyScale.runtime_suite())
@@ -253,7 +254,7 @@ class MamboSuite():
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(
             OpalSysfsTests.Skiroot))
         self.s.addTest(OpalMsglog.Skiroot())
-        self.s.addTest(KernelLog.Skiroot())
+#        self.s.addTest(KernelLog.skiroot_klog_suite())
         self.s.addTest(DPO.DPOSkiroot())
 #        self.s.addTest(OpTestEnergyScale.runtime_suite())
         self.s.addTest(PetitbootMMU.PetitbootMMU())
@@ -270,6 +271,7 @@ class HostSuite():
         self.s.addTest(SystemLogin.OOBHostLogin())
         # disabling temporarily
 #        self.s.addTest(DeviceTreeWarnings.Host())
+#        self.s.addTest(OpTestModel.host_model_suite())
         self.s.addTest(OpTestOCC.basic_suite())
         self.s.addTest(unittest.TestLoader(
         ).loadTestsFromTestCase(IplParams.Host))
@@ -294,13 +296,12 @@ class HostSuite():
         self.s.addTest(DeviceTreeValidation.DeviceTreeValidationHost())
         # disabling temporarily
 #        self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(OpalSysfsTests.Host))
-        # disabling temporarily
-#        self.s.addTest(KernelLog.Host()) # We run before HMI to clear out HMI errors from kernel log
         self.s.addTest(OpTestHMIHandling.suite())
         self.s.addTest(OpTestPNOR.Host())
         # disabling temporarily
 #        self.s.addTest(OpalMsglog.Host())
-#        self.s.addTest(KernelLog.Host())
+        # disabling temporarily
+#        self.s.addTest(KernelLog.host_klog_suite()) # We run before HMI to clear out HMI errors from kernel log
         self.s.addTest(OpTestOCC.OCC_RESET())
         self.s.addTest(gcov.Host())
 
@@ -389,7 +390,7 @@ class QemuSuite():
         self.s.addTest(unittest.TestLoader().loadTestsFromTestCase(
             OpalSysfsTests.Skiroot))
         self.s.addTest(OpalMsglog.Skiroot())
-        self.s.addTest(KernelLog.Skiroot())
+#        self.s.addTest(KernelLog.skiroot_klog_suite())
         self.s.addTest(DPO.DPOSkiroot())
         self.s.addTest(PetitbootMMU.PetitbootMMU())
 
@@ -416,8 +417,7 @@ class FullSuite():
         self.s.addTest(OpalErrorLog.FullTest())
         self.s.addTest(OpTestSwitchEndianSyscall.OpTestSwitchEndianSyscall())
         self.s.addTest(OpalMsglog.Host())
-        self.s.addTest(KernelLog.Host())
-
+        self.s.addTest(KernelLog.host_klog_suite())
     def suite(self):
         return self.s
 
@@ -711,6 +711,15 @@ class OpTestExampleSuite():
     def suite(self):
         return self.s
 
+class OpTestModelSuite():
+    '''Tests in OpTestModel'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(OpTestModel.skiroot_model_suite())
+        self.s.addTest(OpTestModel.host_model_suite())
+
+    def suite(self):
+        return self.s
 
 class OpenBMCPalmettoSkirootSuite():
     '''Tests that pass for an OpenBMC Palmetto, restricted to Petitboot environment'''
@@ -748,7 +757,7 @@ class OpenBMCPalmettoSkirootSuite():
             OpalSysfsTests.Skiroot))
         # duplicate sensors and partition verification fails
         # self.s.addTest(OpalMsglog.Skiroot())
-        self.s.addTest(KernelLog.Skiroot())
+        self.s.addTest(KernelLog.skiroot_klog_suite())
         self.s.addTest(DPO.DPOSkiroot())
 #        self.s.addTest(OpTestEnergyScale.runtime_suite())
 
@@ -822,6 +831,7 @@ suites = {
     'palmetto-ci': OpenBMCPalmettoSkirootSuite(),
     'per-commit': OpTestPerCommitSuite(),
     'pull-request': OpTestPullRequestSuite(),
+    'model' : OpTestModelSuite(),
 }
 
 try:

--- a/testcases/AT24driver.py
+++ b/testcases/AT24driver.py
@@ -46,7 +46,6 @@ import unittest
 
 import OpTestConfiguration
 from testcases.I2C import I2C
-from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed, KernelModuleNotLoaded
 from common.Exceptions import KernelConfigNotSet
 import difflib

--- a/testcases/BMCResetTorture.py
+++ b/testcases/BMCResetTorture.py
@@ -42,7 +42,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/BasicIPL.py
+++ b/testcases/BasicIPL.py
@@ -31,7 +31,8 @@ import unittest
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
+import common.OpTestUtil as Util
 from common.OpTestError import OpTestError
 
 import logging
@@ -40,13 +41,26 @@ log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 
 class BasicIPL(unittest.TestCase):
+    '''
+    BasicIPL class which leverages the OpCheck class
+    to perform various checks pre and post class (if the
+    system wide check_up is being run).
+
+    '''
+    @classmethod
+    def setUpClass(cls):
+        cls.conf = OpTestConfiguration.conf
+        cls.opcheck = Util.OpCheck(cls=cls, helper=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opcheck.check_up(stage="stop")
+
     def setUp(self):
-        conf = OpTestConfiguration.conf
-        self.cv_HOST = conf.host()
-        self.cv_IPMI = conf.ipmi()
-        self.cv_SYSTEM = conf.system()
-        self.cv_BMC = conf.bmc()
-        self.pci_good_data_file = conf.lspci_file()
+        self.cv_HOST = self.conf.host()
+        self.cv_SYSTEM = self.conf.system()
+        self.cv_BMC = self.conf.bmc()
+        self.pci_good_data_file = self.conf.lspci_file()
 
 
 class BootToPetitboot(BasicIPL):

--- a/testcases/BootTorture.py
+++ b/testcases/BootTorture.py
@@ -43,7 +43,7 @@ import difflib
 
 import OpTestConfiguration
 from common.OpTestUtil import OpTestUtil
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -33,7 +33,7 @@ import pexpect
 import time
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 import common.OpTestMambo as OpTestMambo
 

--- a/testcases/ConsoleBug150765.py
+++ b/testcases/ConsoleBug150765.py
@@ -46,7 +46,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 
 class ConsoleBug150765(unittest.TestCase):

--- a/testcases/CpuHotPlug.py
+++ b/testcases/CpuHotPlug.py
@@ -38,7 +38,7 @@ we put cores/threads into when we hot unplug them.
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/DPO.py
+++ b/testcases/DPO.py
@@ -39,7 +39,7 @@ from common.OpTestError import OpTestError
 import unittest
 import pexpect
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 import common.OpTestQemu as OpTestQemu
 import common.OpTestMambo as OpTestMambo
 

--- a/testcases/DeviceTreeValidation.py
+++ b/testcases/DeviceTreeValidation.py
@@ -40,7 +40,7 @@ import OpTestConfiguration
 from common.Exceptions import CommandFailed
 from common.OpTestError import OpTestError
 from common.OpTestSystem import OpSystemState
-from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestConstants import OpConstants as OpSystemState
 import common.OpTestQemu as OpTestQemu
 import logging
 import OpTestLogger

--- a/testcases/DeviceTreeWarnings.py
+++ b/testcases/DeviceTreeWarnings.py
@@ -33,7 +33,7 @@ import unittest
 import re
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 

--- a/testcases/EMStress.py
+++ b/testcases/EMStress.py
@@ -28,7 +28,7 @@ import time
 import threading
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestThread import OpSSHThreadLinearVar1, OpSSHThreadLinearVar2
 from common.OpTestSOL import OpSOLMonitorThread

--- a/testcases/EPOW.py
+++ b/testcases/EPOW.py
@@ -55,7 +55,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger
@@ -69,7 +69,6 @@ class EPOWBase(unittest.TestCase):
         self.cv_SYSTEM = conf.system()
         self.cv_HOST = conf.host()
         self.cv_FSP = conf.bmc()
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.util = self.cv_SYSTEM.util
         self.cv_SYSTEM.goto_state(OpSystemState.OS)

--- a/testcases/EnergyScale_BaseLine.py
+++ b/testcases/EnergyScale_BaseLine.py
@@ -39,7 +39,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging
@@ -54,7 +54,6 @@ class EnergyScale_BaseLine(unittest.TestCase):
         self.cv_SYSTEM = conf.system()
         self.cv_HOST = conf.host()
         self.cv_BMC = conf.bmc()
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
 

--- a/testcases/FWTS.py
+++ b/testcases/FWTS.py
@@ -40,7 +40,7 @@ import os
 
 import OpTestConfiguration
 import unittest
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 import common.OpTestMambo as OpTestMambo
 import common.OpTestQemu as OpTestQemu

--- a/testcases/HelloWorld.py
+++ b/testcases/HelloWorld.py
@@ -29,8 +29,6 @@ Only useful as a unittest of `op-test` itself.
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
-
 
 class HelloWorld(unittest.TestCase):
     def setUp(self):

--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -40,7 +40,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed, KernelModuleNotLoaded
 from common.Exceptions import KernelConfigNotSet
 

--- a/testcases/InstallHostOS.py
+++ b/testcases/InstallHostOS.py
@@ -30,7 +30,7 @@ import unittest
 import os
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common import OpTestInstallUtil
 
 

--- a/testcases/InstallRhel.py
+++ b/testcases/InstallRhel.py
@@ -30,7 +30,7 @@ import os
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common import OpTestInstallUtil
 
 import logging

--- a/testcases/InstallUbuntu.py
+++ b/testcases/InstallUbuntu.py
@@ -34,7 +34,7 @@ import pexpect
 import os
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common import OpTestInstallUtil
 
 import logging

--- a/testcases/IplParams.py
+++ b/testcases/IplParams.py
@@ -30,7 +30,7 @@ enablement of certain components.
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import common.OpTestMambo as OpTestMambo

--- a/testcases/IpmiTorture.py
+++ b/testcases/IpmiTorture.py
@@ -31,7 +31,7 @@ import time
 import threading
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 
 

--- a/testcases/LightPathDiagnostics.py
+++ b/testcases/LightPathDiagnostics.py
@@ -41,7 +41,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/OpTestCAPI.py
+++ b/testcases/OpTestCAPI.py
@@ -49,7 +49,7 @@ import re
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
 

--- a/testcases/OpTestDumps.py
+++ b/testcases/OpTestDumps.py
@@ -49,7 +49,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger
@@ -64,7 +64,6 @@ class OpTestDumps():
         self.cv_FSP = self.cv_SYSTEM.bmc
         self.cv_HOST = conf.host()
         self.util = self.cv_SYSTEM.util
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
 

--- a/testcases/OpTestEEH.py
+++ b/testcases/OpTestEEH.py
@@ -44,7 +44,7 @@ import os
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -45,7 +45,7 @@ import decimal
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 from common.OpTestIPMI import IPMIConsoleState
 import common.OpTestQemu as OpTestQemu

--- a/testcases/OpTestEnergyScale.py
+++ b/testcases/OpTestEnergyScale.py
@@ -43,7 +43,7 @@ import sys
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 

--- a/testcases/OpTestExample.py
+++ b/testcases/OpTestExample.py
@@ -30,7 +30,7 @@ import logging
 
 import OpTestConfiguration
 import OpTestLogger
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 try:
     import pxssh

--- a/testcases/OpTestFastReboot.py
+++ b/testcases/OpTestFastReboot.py
@@ -44,7 +44,7 @@ import sys
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -50,7 +50,7 @@ import unittest
 import tarfile
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
@@ -69,7 +69,6 @@ class OpTestFlashBase(unittest.TestCase):
         self.cv_REST = self.cv_BMC.get_rest_api()
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
-        self.platform = conf.platform()
         self.util = conf.util
         self.OpIU = OpTestInstallUtil.InstallUtil()
         self.bmc_type = conf.args.bmc_type

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -48,10 +48,11 @@ import pexpect
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestSSH import ConsoleState as SSHConnectionState
 from common.OpTestIPMI import IPMIConsoleState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
+import common.OpTestUtil as Util
 from common.Exceptions import CommandFailed, UnknownStateTransition, PlatformError, HostbootShutdown, StoppingSystem
 
 import logging
@@ -62,13 +63,17 @@ log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 class OpTestHMIHandling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        conf = OpTestConfiguration.conf
-        cls.cv_HOST = conf.host()
-        cls.cv_IPMI = conf.ipmi()
-        cls.cv_FSP = conf.bmc()
-        cls.cv_SYSTEM = conf.system()
-        cls.bmc_type = conf.args.bmc_type
-        cls.util = conf.util
+        cls.conf = OpTestConfiguration.conf
+        cls.cv_HOST = cls.conf.host()
+        cls.cv_FSP = cls.conf.bmc()
+        cls.cv_SYSTEM = cls.conf.system()
+        cls.bmc_type = cls.conf.args.bmc_type
+        cls.util = cls.conf.util
+        cls.opcheck = Util.OpCheck(cls=cls, helper=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opcheck.check_up(stage="stop") # performs standard checks POST Class
 
     def setUp(self):
         if self.cv_SYSTEM.get_state() == OpSystemState.UNKNOWN_BAD:

--- a/testcases/OpTestHeartbeat.py
+++ b/testcases/OpTestHeartbeat.py
@@ -37,7 +37,7 @@ This class will test the functionality of ipmi heartbeat
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 
 class HeartbeatSkiroot(unittest.TestCase):

--- a/testcases/OpTestHostboot.py
+++ b/testcases/OpTestHostboot.py
@@ -32,7 +32,7 @@ import string
 
 import OpTestConfiguration
 import OpTestLogger
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 

--- a/testcases/OpTestIPMILockMode.py
+++ b/testcases/OpTestIPMILockMode.py
@@ -47,7 +47,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/OpTestIPMIReprovision.py
+++ b/testcases/OpTestIPMIReprovision.py
@@ -45,7 +45,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 
 class OpTestIPMIReprovision(unittest.TestCase):

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -47,7 +47,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestIPMI import IPMIConsoleState
 from common.Exceptions import CommandFailed
 import common.OpTestMambo as OpTestMambo

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -50,7 +50,6 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
 from testcases.OpTestInbandIPMI import BasicInbandIPMI, OpTestInbandIPMI, ExperimentalInbandIPMI
 from testcases.OpTestInbandIPMI import SkirootBasicInbandIPMI, SkirootFullInbandIPMI
 

--- a/testcases/OpTestMamboSim.py
+++ b/testcases/OpTestMamboSim.py
@@ -39,7 +39,7 @@ import time
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 import common.OpTestMambo as OpTestMambo
 

--- a/testcases/OpTestModel.py
+++ b/testcases/OpTestModel.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python2
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2017
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+'''
+OpTestModel: A Model test case
+------------------------------
+
+This test case is to illustrate a few best practices for leveraging
+the OpCheck helpers to perform some system wide health checks.
+
+'''
+
+import unittest
+import time
+
+import OpTestConfiguration
+from common.OpTestConstants import OpConstants as OpSystemState
+import common.OpTestUtil as Util
+
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+class OpModel(unittest.TestCase):
+    '''
+    OpModel is an illustration of how to use the OpCheck class and
+    use a standard methodology for setting up classes to be shared
+    within a module.
+    '''
+    @classmethod
+    def setUpClass(cls):
+        cls.conf = OpTestConfiguration.conf
+        if cls.conf.args.bmc_type in ['qemu', 'mambo']:
+            raise unittest.SkipTest("QEMU/Mambo running so skipping tests")
+        cls.opcheck = Util.OpCheck(cls=cls) # OpCheck helper for standard setup
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opcheck.check_up(stage="stop") # performs standard checks POST Class
+
+    def lsprop_check(self, stage=None, diff_dict=None):
+        fn_label = "lspropfw" # fn_label should match what to compare it to
+        command = "lsprop /sys/firmware/devicetree/base/ibm,firmware-versions"
+        dict_stage = {} # we need new object each time
+        diff_dict[stage] = Util.dump_me(self=self,
+                                    term_obj=self.c,
+                                    conf=self.conf,
+                                    dict_stage=dict_stage,
+                                    stage=stage,
+                                    fn_label=fn_label,
+                                    command=command)
+
+    def lspci_check(self, stage=None, diff_dict=None):
+        fn_label = "pci" # fn_label should match what to compare it to
+        command = "lspci"
+        dict_stage = {} # we need new object each time
+        diff_dict[stage] = Util.dump_me(self=self,
+                                    term_obj=self.c,
+                                    conf=self.conf,
+                                    dict_stage=dict_stage,
+                                    stage=stage,
+                                    fn_label=fn_label,
+                                    command=command)
+
+    def uptime_check(self, stage=None, diff_dict=None):
+        fn_label = "timeup" # fn_label should match what to compare it to
+        command = "uptime"
+        dict_stage = {} # we need new object each time
+        diff_dict[stage] = Util.dump_me(self=self,
+                                    term_obj=self.c,
+                                    conf=self.conf,
+                                    dict_stage=dict_stage,
+                                    stage=stage,
+                                    fn_label=fn_label,
+                                    command=command)
+
+    def df_check(self, stage=None, diff_dict=None):
+        fn_label = "df" # fn_label should match what to compare it to
+        command = "df -h"
+        dict_stage = {} # we need new object each time
+        diff_dict[stage] = Util.dump_me(self=self,
+                                    term_obj=self.c,
+                                    conf=self.conf,
+                                    dict_stage=dict_stage,
+                                    stage=stage,
+                                    fn_label=fn_label,
+                                    command=command)
+
+    def setUp(self):
+        '''
+        Demonstrate setUp which happens before each test_*
+        This is to capture state information to compare with post-test
+        Typically these may be checks that should remain static.
+        '''
+        self.diff_dict = {} # we create the dict here, fresh each setUp
+        stage = "start"
+        self.lsprop_check(stage=stage, diff_dict=self.diff_dict)
+        self.lspci_check(stage=stage, diff_dict=self.diff_dict)
+
+    def tearDown(self):
+        '''
+        Demonstrate tearDown which happens after each test_*
+        This is to catch any problems that happened during the test
+        Typically these may be checks that should remain static.
+        '''
+        stage = "stop"
+        self.lsprop_check(stage=stage, diff_dict=self.diff_dict)
+        self.lspci_check(stage=stage, diff_dict=self.diff_dict)
+
+        self.status = Util.diff_files(diff_dict=self.diff_dict)
+        self.assertFalse(self.status, "We've got diff problems!")
+
+class HostOS(OpModel, unittest.TestCase):
+    '''
+    Model Class to illustrate leveraging the setUpClass
+    and OpCheck Class.
+
+    This model allows unittest fixtures to inherit
+    common tests which only differ by where they are
+    executed, e.g. HostOS or in Skiroot.
+
+    The methods below need to start with test_ for
+    unittest to leverage the loading of the methods
+    and the automatic calling of setUp/tearDown per test.
+    '''
+    @classmethod
+    def setUpClass(cls):
+        log.debug("HostOS setUpClass setting cls.desired=OS")
+        cls.desired = OpSystemState.OS
+        super(HostOS, cls).setUpClass()
+
+    def test_A(self):
+        '''
+        Example test_A to show how to use the capturing
+        of data to be used after the test to compare
+        '''
+        diff_dict = {}
+        stage = "test_A_start"
+        self.df_check(stage=stage, diff_dict=diff_dict)
+        time.sleep(5)
+        stage = "test_A_stop"
+        self.df_check(stage=stage, diff_dict=diff_dict)
+        self.status = Util.diff_files(diff_dict=diff_dict)
+        self.assertFalse(self.status, "Something changed !")
+
+    def test_B(self):
+        '''
+        Example test_B to show how to use the capturing
+        of data to be used after the test to compare
+        '''
+        diff_dict = {}
+        stage = "test_B_start"
+        self.uptime_check(stage=stage, diff_dict=diff_dict)
+        time.sleep(5)
+        stage = "test_B_stop"
+        self.uptime_check(stage=stage, diff_dict=diff_dict)
+        self.status = Util.diff_files(diff_dict=diff_dict,
+                         logdir=self.conf.logdir)
+        self.assertTrue(self.status,
+            "We should have had a diff problem! Times should not match")
+
+class PetitbootShell(HostOS):
+    '''
+    Model Class to illustrate leveraging the setUpClass
+    and OpCheck Class.
+
+    This model allows unittest fixtures to inherit
+    common tests which only differ by where they are
+    executed, e.g. HostOS or in Skiroot.
+    '''
+    @classmethod
+    def setUpClass(cls):
+        log.debug("Petitboot setUpClass setting cls.desired=PS")
+        cls.desired = OpSystemState.PETITBOOT_SHELL
+        super(HostOS, cls).setUpClass()
+
+def host_model_suite():
+    s = unittest.TestSuite()
+    s.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HostOS))
+    return s
+
+def skiroot_model_suite():
+    s = unittest.TestSuite()
+    s.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PetitbootShell))
+    return s

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -47,7 +47,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/OpTestNVRAM.py
+++ b/testcases/OpTestNVRAM.py
@@ -45,7 +45,7 @@ import os.path
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 import logging

--- a/testcases/OpTestOCC.py
+++ b/testcases/OpTestOCC.py
@@ -47,7 +47,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import testcases.OpTestEM
@@ -64,7 +64,6 @@ class OpTestOCCBase(testcases.OpTestEM.OpTestEM):
         self.cv_SYSTEM = conf.system()
         self.cv_HOST = conf.host()
         self.cv_FSP = conf.bmc()
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.rest = conf.system().rest
         self.cv_SYSTEM.goto_state(OpSystemState.OS)

--- a/testcases/OpTestOOBIPMI.py
+++ b/testcases/OpTestOOBIPMI.py
@@ -48,8 +48,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpTestSystem
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger
@@ -62,8 +61,6 @@ class OpTestOOBIPMIBase(unittest.TestCase):
         self.cv_HOST = conf.host()
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
-        self.platform = conf.platform()
-        pass
 
     def run_ipmi_cmd(self, i_cmd):
         '''

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -47,7 +47,6 @@ the applicable options per method.
 '''
 
 import unittest
-import logging
 import pexpect
 import time
 import re
@@ -55,11 +54,15 @@ import difflib
 from distutils.version import LooseVersion
 
 import OpTestConfiguration
-import OpTestLogger
-from common.OpTestSystem import OpSystemState
+from distutils.version import LooseVersion
+from common.OpTestConstants import OpTestConstants as BMC_CONST
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed, UnexpectedCase
 
+import logging
+import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 skiroot_done = 0
 host_done = 0
 skiroot_lspci = None

--- a/testcases/OpTestPNOR.py
+++ b/testcases/OpTestPNOR.py
@@ -43,7 +43,7 @@ import os.path
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 import logging

--- a/testcases/OpTestPrdDaemon.py
+++ b/testcases/OpTestPrdDaemon.py
@@ -52,7 +52,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -57,7 +57,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestError import OpTestError
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging
@@ -82,7 +82,6 @@ class OpTestPrdDriver(unittest.TestCase):
         self.cv_IPMI = conf.ipmi()
         self.cv_SYSTEM = conf.system()
         self.cv_HOST = conf.host()
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
 

--- a/testcases/OpTestRTCdriver.py
+++ b/testcases/OpTestRTCdriver.py
@@ -42,7 +42,7 @@ import re
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/OpTestRebootTimeout.py
+++ b/testcases/OpTestRebootTimeout.py
@@ -31,7 +31,7 @@ import time
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 
 import logging

--- a/testcases/OpTestSensors.py
+++ b/testcases/OpTestSensors.py
@@ -42,7 +42,7 @@ import re
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
 

--- a/testcases/OpTestSwitchEndianSyscall.py
+++ b/testcases/OpTestSwitchEndianSyscall.py
@@ -48,7 +48,7 @@ import re
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestError import OpTestError
 from common.Exceptions import CommandFailed
 

--- a/testcases/OpTestSystemBootSequence.py
+++ b/testcases/OpTestSystemBootSequence.py
@@ -61,7 +61,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.OpTestError import OpTestError
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 
 class OpTestSystemBootSequence(unittest.TestCase):
@@ -72,7 +72,6 @@ class OpTestSystemBootSequence(unittest.TestCase):
         self.cv_BMC = self.cv_SYSTEM.bmc
         self.cv_HOST = conf.host()
         self.util = self.cv_SYSTEM.util
-        self.platform = conf.platform()
         self.bmc_type = conf.args.bmc_type
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
 

--- a/testcases/OpalErrorLog.py
+++ b/testcases/OpalErrorLog.py
@@ -43,7 +43,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/OpalGard.py
+++ b/testcases/OpalGard.py
@@ -38,7 +38,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -32,7 +32,7 @@ import unittest
 import re
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 

--- a/testcases/OpalSysfsTests.py
+++ b/testcases/OpalSysfsTests.py
@@ -39,7 +39,7 @@ import random
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 
 import logging
 import OpTestLogger

--- a/testcases/OpalUtils.py
+++ b/testcases/OpalUtils.py
@@ -44,7 +44,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/PciSlotLocCodes.py
+++ b/testcases/PciSlotLocCodes.py
@@ -36,7 +36,8 @@ import re
 import os
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
+import common.OpTestUtil as Util
 from common.Exceptions import CommandFailed
 
 import logging
@@ -54,18 +55,11 @@ class PciDT(unittest.TestCase):
         cls.conf = OpTestConfiguration.conf
         if cls.conf.args.bmc_type in ['qemu', 'mambo']:
             raise unittest.SkipTest("QEMU/Mambo running so skipping tests")
-        cls.cv_SYSTEM = cls.conf.system()
-        try:
-            if cls.desired == OpSystemState.OS:
-                cls.c = cls.cv_SYSTEM.cv_HOST.get_ssh_connection()
-                cls.cv_SYSTEM.goto_state(OpSystemState.OS)
-            else:
-                cls.c = cls.cv_SYSTEM.console
-                cls.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
-        except Exception as e:
-            log.debug("Unable to find cls.desired, probably a test code problem")
-            cls.c = cls.cv_SYSTEM.console
-            cls.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
+        cls.opcheck = Util.OpCheck(cls=cls) # OpCheck helper for standard setup
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opcheck.check_up(stage="stop") # performs standard checks POST Class
 
     def dump_lspci(self, lspci_dict):
         for key, value in list(lspci_dict.items()):

--- a/testcases/PetitbootDropbearServer.py
+++ b/testcases/PetitbootDropbearServer.py
@@ -45,7 +45,7 @@ import sys
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)

--- a/testcases/Petitbooti18n.py
+++ b/testcases/Petitbooti18n.py
@@ -34,7 +34,7 @@ import pexpect
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 import common.OpTestMambo as OpTestMambo
 import logging
 import OpTestLogger

--- a/testcases/RunHostTest.py
+++ b/testcases/RunHostTest.py
@@ -31,10 +31,9 @@ import unittest
 import os
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestSOL import OpSOLMonitorThread
 from common.OpTestSOL import OpSOLMonitorThreadVM
-
 
 class RunHostTest(unittest.TestCase):
     def setUp(self):

--- a/testcases/SbePassThrough.py
+++ b/testcases/SbePassThrough.py
@@ -36,7 +36,7 @@ import unittest
 import time
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/SecureBoot.py
+++ b/testcases/SecureBoot.py
@@ -27,7 +27,7 @@ import unittest
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 from testcases.OpTestFlash import PNORFLASH

--- a/testcases/SystemLogin.py
+++ b/testcases/SystemLogin.py
@@ -35,7 +35,7 @@ import os
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 import common.OpTestQemu as OpTestQemu
 import common.OpTestMambo as OpTestMambo

--- a/testcases/TrustedBoot.py
+++ b/testcases/TrustedBoot.py
@@ -44,7 +44,7 @@ import unittest
 import pexpect
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 

--- a/testcases/fspTODCorruption.py
+++ b/testcases/fspTODCorruption.py
@@ -40,7 +40,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestSSH import ConsoleState as SSHConnectionState
 
 import logging

--- a/testcases/fspresetReload.py
+++ b/testcases/fspresetReload.py
@@ -41,7 +41,7 @@ from common.OpTestError import OpTestError
 
 import unittest
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import CommandFailed
 
 import logging

--- a/testcases/gcov.py
+++ b/testcases/gcov.py
@@ -30,7 +30,7 @@ import os
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 from common import OpTestInstallUtil

--- a/testcases/testRestAPI.py
+++ b/testcases/testRestAPI.py
@@ -37,7 +37,7 @@ import os
 import unittest
 
 import OpTestConfiguration
-from common.OpTestSystem import OpSystemState
+from common.OpTestConstants import OpConstants as OpSystemState
 from common.Exceptions import HTTPCheck
 
 import logging


### PR DESCRIPTION
Add a new helper class OpCheck.  This helper class will allow
testcases which instrument the testcase with the OpCheck class
helper to dynamically perform system wide health checks when
the system wide switch is turned on.

Adding --check-up as a switch to the op-test invocation will
enable the instrumentation to perform some pre and post
testcase class checks dynamically.

When --check-up is added to the op-test arguments, additional
output files will be placed in the logdir for analysis.  When the
--check-up switch is enabled the op-test exit code may be
altered if health checks identify issues to be further investigated.
OpExit code of 117 (errno.EUCLEAN).  <logdir>/opcheck_list* will
provide a summary of the data collected and suggestions for review.

Currently the esel, dmesg and msglog are the common checks performed
(if the system is in a state to collect, e.g. if system is OFF,
no dmesg or msglog are able to be collected).

When --check-up is not explicitly added, no additional checks are
performed nor will the op-test exit code be modified.

OpTestModel testcase is added as an additional resource and
implementation of the OpCheck class helper, as well as illustrating
how to perform custom exploitation of the methods available.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>