### PR TITLE
Add op-build-pull-request suite

### DIFF
--- a/op-test
+++ b/op-test
@@ -619,6 +619,17 @@ class OpenBMCPalmettoSkirootSuite():
     def suite(self):
         return self.s
 
+class OpBuildPRSuite():
+    '''Run on each opened Pull Request on op-build project'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(SystemAccessSuite().suite())
+        self.s.addTest(OpTestHostbootSuite().suite())
+        self.s.addTest(SkirootSuite().suite())
+        pass
+    def suite(self):
+        return self.s
+
 suites = {
     'system-access' : SystemAccessSuite(),
     'skiroot' : SkirootSuite(),
@@ -655,6 +666,7 @@ suites = {
     'hostboot' : OpTestHostbootSuite(),
     'example' : OpTestExampleSuite(),
     'palmetto-ci' : OpenBMCPalmettoSkirootSuite(),
+    'op-build-pull-request' : OpBuildPRSuite(),
 }
 
 try:


### PR DESCRIPTION
Soon, op-test-framework will appear as a submodule in op-build,
and CI jobs for op-build will look at the version of
op-test that the submodule points at, and run the
'op-build-pull-request' suite specified there.

The idea being that this connects "this op-build commit passes this
op-test commit's suite X"

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>