### PR TITLE
RFC: Add support to run on both Python2 and Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ git:
 addons:
   apt:
     packages:
-      - python-pip
+      - python3-pip
       - latexmk
       - libalgorithm-diff-perl
       - texlive
@@ -24,13 +24,13 @@ addons:
 
 language: python
 python:
-  - "2.7"
+  - "3.6"
 install:
- - "pip install -r requirements.txt"
- - "pip install -r doc/requirements.txt"
+ - "pip3 install -r requirements.txt"
+ - "pip3 install -r doc/requirements.txt"
 script:
-  - python op-test --help
-  - python op-test --bmc-type AMI --run testcases.HelloWorld
+  - python3 op-test --help
+  - python3 op-test --bmc-type AMI --run testcases.HelloWorld
   - (cd doc/; make latexpdf html)
   - ./ci/build-qemu-powernv.sh
   - wget https://openpower.xyz/job/openpower/job/openpower-op-build/label=slave,target=palmetto/lastSuccessfulBuild/artifact/images/palmetto.pnor

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -1,8 +1,12 @@
+from __future__ import print_function
 
 # This implements all the configuration needs for running a test
 # It includes command line argument parsing and keeping a set
 # of OpTestSystem and similar objects around for tests to use.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import common
 from common.OpTestBMC import OpTestBMC, OpTestSMC
 from common.OpTestFSP import OpTestFSP
@@ -25,7 +29,7 @@ import traceback
 from datetime import datetime
 import subprocess
 import sys
-import ConfigParser
+import configparser
 import errno
 import OpTestLogger
 import logging
@@ -339,7 +343,7 @@ def get_parser():
 
     return parser
 
-class OpTestConfiguration():
+class OpTestConfiguration(object):
     def __init__(self):
         self.util = OpTestUtil(self) # initialize OpTestUtil with this object the OpTestConfiguration
         self.cronus = OpTestCronus(self) # initialize OpTestCronus with this object the OpTestConfiguration
@@ -381,7 +385,7 @@ class OpTestConfiguration():
 
         args , remaining_args = conf_parser.parse_known_args(argv)
         defaults = {}
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.SafeConfigParser()
         config.read([os.path.expanduser("~/.op-test-framework.conf")])
         if args.config_file:
             if os.access(args.config_file, os.R_OK):
@@ -390,7 +394,7 @@ class OpTestConfiguration():
                 raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), args.config_file)
         try:
             defaults = dict(config.items('op-test'))
-        except ConfigParser.NoSectionError:
+        except configparser.NoSectionError:
             pass
 
         parser = get_parser()

--- a/common/Exceptions.py
+++ b/common/Exceptions.py
@@ -260,7 +260,7 @@ class UnexpectedCase(Exception):
         default_vals = {'state': None, 'message': None}
         self.kwargs = {}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 self.kwargs[key] = default_vals[key]
             else:
                 self.kwargs[key] = kwargs[key]
@@ -282,7 +282,7 @@ class WaitForIt(Exception):
         default_vals = {'expect_dict': None, 'reconnect_count': 0}
         self.kwargs = {}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 self.kwargs[key] = default_vals[key]
             else:
                 self.kwargs[key] = kwargs[key]
@@ -302,7 +302,7 @@ class RecoverFailed(Exception):
         default_vals = {'before': None, 'after': None, 'msg': None}
         self.kwargs = {}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 self.kwargs[key] = default_vals[key]
             else:
                 self.kwargs[key] = kwargs[key]
@@ -324,7 +324,7 @@ class UnknownStateTransition(Exception):
         default_vals = {'state': None, 'message': None}
         self.kwargs = {}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 self.kwargs[key] = default_vals[key]
             else:
                 self.kwargs[key] = kwargs[key]
@@ -347,7 +347,7 @@ class HostLocker(Exception):
         default_vals = {'message': None}
         self.kwargs = {}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             self.kwargs[key] = default_vals[key]
           else:
             self.kwargs[key] = kwargs[key]
@@ -368,7 +368,7 @@ class HTTPCheck(Exception):
         default_vals = {'message': None}
         self.kwargs = {}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             self.kwargs[key] = default_vals[key]
           else:
             self.kwargs[key] = kwargs[key]
@@ -393,7 +393,7 @@ class OpExit(SystemExit):
         default_vals = {'message': None, 'code': 0}
         self.kwargs = {}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             self.kwargs[key] = default_vals[key]
           else:
             self.kwargs[key] = kwargs[key]
@@ -410,7 +410,7 @@ class AES(Exception):
         default_vals = {'message': None}
         self.kwargs = {}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             self.kwargs[key] = default_vals[key]
           else:
             self.kwargs[key] = kwargs[key]
@@ -432,7 +432,7 @@ class ParameterCheck(Exception):
         default_vals = {'message': None}
         self.kwargs = {}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             self.kwargs[key] = default_vals[key]
           else:
             self.kwargs[key] = kwargs[key]
@@ -465,7 +465,7 @@ class ConsoleSettings(Exception):
         default_vals = {'before': None, 'after': None, 'msg': None}
         self.kwargs = {}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 self.kwargs[key] = default_vals[key]
             else:
                 self.kwargs[key] = kwargs[key]

--- a/common/OPexpect.py
+++ b/common/OPexpect.py
@@ -33,10 +33,12 @@ When developing test cases, use OPexpect over pexpect. If you *intend* for
 certain error conditions to occur, you can catch the exceptions that OPexpect
 throws.
 """
+from __future__ import absolute_import
 
+from builtins import str
 import pexpect
-from Exceptions import *
-import OpTestSystem
+from .Exceptions import *
+from . import OpTestSystem
 
 class spawn(pexpect.spawn):
     def __init__(self, command, args=[], maxread=8000,

--- a/common/OpTestASM.py
+++ b/common/OpTestASM.py
@@ -33,20 +33,25 @@ This class can contains common functions which are useful for
 FSP ASM Web page. Some functionality is only accessible through
 the FSP Web UI (such as progress codes), so we scrape it.
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import time
 import subprocess
 import os
 import pexpect
 import sys
-import commands
+import subprocess
 
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
 
-import cookielib
-import urllib
-import urllib2
+import http.cookiejar
+import urllib.request, urllib.parse, urllib.error
+import urllib.request, urllib.error, urllib.parse
 import re
 import ssl
 # Work around issues with python < 2.7.9
@@ -56,16 +61,16 @@ except AttributeError:
     pass
 
 
-class OpTestASM:
+class OpTestASM(object):
     def __init__(self, i_fspIP, i_fspUser, i_fspPasswd):
         self.host_name = i_fspIP
         self.user_name = i_fspUser
         self.password = i_fspPasswd
         self.url = "https://%s/cgi-bin/cgi?" % self.host_name
-        self.cj = cookielib.CookieJar()
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cj))
+        self.cj = http.cookiejar.CookieJar()
+        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.cj))
         opener.addheaders = [('User-agent', 'LTCTest')]
-        urllib2.install_opener(opener)
+        urllib.request.install_opener(opener)
         self.setforms()
 
     def setforms(self):
@@ -83,8 +88,8 @@ class OpTestASM:
     def getcsrf(self, form):
         while True:
             try:
-                myurl = urllib2.urlopen(self.url+form, timeout=10)
-            except urllib2.URLError:
+                myurl = urllib.request.urlopen(self.url+form, timeout=10)
+            except urllib.error.URLError:
                 time.sleep(2)
                 continue
             break
@@ -97,8 +102,8 @@ class OpTestASM:
     def getpage(self, form):
         while True:
             try:
-                myurl = urllib2.urlopen(self.url+form, timeout=60)
-            except (urllib2.URLError, ssl.SSLError):
+                myurl = urllib.request.urlopen(self.url+form, timeout=60)
+            except (urllib.error.URLError, ssl.SSLError):
                 time.sleep(2)
                 continue
             break
@@ -106,10 +111,10 @@ class OpTestASM:
 
     def submit(self, form, param):
         param['CSRF_TOKEN'] = self.getcsrf(form)
-        data = urllib.urlencode(param)
-        req = urllib2.Request(self.url+form, data)
+        data = urllib.parse.urlencode(param)
+        req = urllib.request.Request(self.url+form, data)
 
-        return urllib2.urlopen(req)
+        return urllib.request.urlopen(req)
 
     def login(self):
         if not len(self.cj) == 0:

--- a/common/OpTestBMC.py
+++ b/common/OpTestBMC.py
@@ -33,26 +33,28 @@ BMC package which contains all BMC related interfaces/function.
 This class encapsulates all function which deals with the BMC in OpenPower
 systems
 '''
+from __future__ import absolute_import
 
+from builtins import object
 import sys
 import time
 import pexpect
 import os.path
 import subprocess
 
-from OpTestIPMI import OpTestIPMI
-from OpTestSSH import OpTestSSH
-from OpTestUtil import OpTestUtil
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
-from OpTestWeb import OpTestWeb
-from Exceptions import CommandFailed, SSHSessionDisconnected
+from .OpTestIPMI import OpTestIPMI
+from .OpTestSSH import OpTestSSH
+from .OpTestUtil import OpTestUtil
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
+from .OpTestWeb import OpTestWeb
+from .Exceptions import CommandFailed, SSHSessionDisconnected
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class OpTestBMC():
+class OpTestBMC(object):
     '''
     The main object for communicating with a BMC and taking actions with it.
     '''

--- a/common/OpTestCronus.py
+++ b/common/OpTestCronus.py
@@ -24,6 +24,8 @@
 #
 # IBM_PROLOG_END_TAG
 
+from __future__ import absolute_import
+from builtins import object
 import os
 import datetime
 import time
@@ -31,8 +33,8 @@ import subprocess
 import traceback
 import socket
 
-from Exceptions import ParameterCheck, UnexpectedCase
-from OpTestSystem import OpSystemState
+from .Exceptions import ParameterCheck, UnexpectedCase
+from .OpTestSystem import OpSystemState
 
 import logging
 import OpTestLogger
@@ -58,7 +60,7 @@ match_list = ["CRONUS_HOME",
               "SBE_TOOLS_PATH",
              ]
 
-class OpTestCronus():
+class OpTestCronus(object):
     '''
     OpTestCronus Class for Cronus Setup and Environment Persistance
 

--- a/common/OpTestFSP.py
+++ b/common/OpTestFSP.py
@@ -35,24 +35,30 @@ the FSP itself. There is (currently) no differentiation between
 commands that require the NFS mount and ones that don't, we
 assume (and check for) the NFS mount.
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import time
 import subprocess
 import os
 import pexpect
 import sys
-import commands
+import subprocess
 
-from OpTestTConnection import TConnection
-from OpTestASM import OpTestASM
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
+from .OpTestTConnection import TConnection
+from .OpTestASM import OpTestASM
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
 
 Possible_Hyp_value = {'01': 'PowerVM', '03': 'PowerKVM'}
 Possible_Sys_State = {'terminated':0, 'standby':1, 'prestandby':2, 'ipling':3, 'runtime':4}
 
 
-class OpTestFSP():
+class OpTestFSP(object):
     '''
     Contains most of the common methods to interface with FSP.
     '''

--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -30,7 +30,16 @@ Host package which contains all functions related to HOST communication
 This class encapsulates all function which deals with the Host
 in OpenPower systems
 '''
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
+from builtins import str
+from builtins import object
+from past.utils import old_div
 import sys
 import os
 import string
@@ -43,14 +52,14 @@ import socket
 import select
 import pty
 import pexpect
-import commands
+import subprocess
 
 import OpTestConfiguration
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
-from OpTestSSH import OpTestSSH
-import OpTestQemu
-from Exceptions import CommandFailed, NoKernelConfig, KernelModuleNotLoaded, KernelConfigNotSet, ParameterCheck
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
+from .OpTestSSH import OpTestSSH
+from . import OpTestQemu
+from .Exceptions import CommandFailed, NoKernelConfig, KernelModuleNotLoaded, KernelConfigNotSet, ParameterCheck
 
 import logging
 import OpTestLogger
@@ -60,7 +69,7 @@ import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class OpTestHost():
+class OpTestHost(object):
     '''
     An object to manipulate and run things on the host.
     '''
@@ -122,18 +131,18 @@ class OpTestHost():
         outsuffix = time.strftime("%Y%m%d%H%M%S")
         filename = "%s-%s.log" % (outsuffix, name)
         logfile = os.path.join(self.results_dir,filename)
-        print "Log file: %s" % logfile
+        print("Log file: %s" % logfile)
         logcmd = "tee %s" % (logfile)
         logcmd = logcmd + "| sed -u -e 's/\\r$//g'|cat -v"
-        print "logcmd: %s" % logcmd
+        print("logcmd: %s" % logcmd)
         logfile_proc = subprocess.Popen(logcmd,
                                              stdin=subprocess.PIPE,
                                              stderr=subprocess.PIPE,
                                              stdout=subprocess.PIPE,
                                              shell=True)
-        print repr(logfile_proc)
+        print(repr(logfile_proc))
         logfile = logfile_proc.stdin
-        print "Log file: %s" % logfile
+        print("Log file: %s" % logfile)
         OpTestLogger.optest_logger_glob.setUpCustomLoggerDebugFile(name, filename)
         ssh = OpTestSSH(self.ip, self.user, self.passwd,
                         logfile=logfile, check_ssh_keys=self.check_ssh_keys,
@@ -230,7 +239,7 @@ class OpTestHost():
         '''
         default_vals = {'console': 0}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         l_cmd = 'which ' + ' '.join(i_cmd)
         log.debug(l_cmd)
@@ -697,7 +706,7 @@ class OpTestHost():
 
         for i in core_ids:
             core_ids[i] = list(set(core_ids[i]))
-        core_ids = sorted(core_ids.iteritems())
+        core_ids = sorted(core_ids.items())
         log.debug(core_ids)
         return core_ids
 
@@ -731,7 +740,7 @@ class OpTestHost():
 
     def host_get_core_count(self, console=0):
         res = self.host_run_command("lscpu --all -e| wc -l", console=console)
-        return int(res[0])/(self.host_get_smt(console=console))
+        return old_div(int(res[0]),(self.host_get_smt(console=console)))
 
     def host_gather_debug_logs(self, console=0):
         self.host_run_command("grep ',[0-4]\]' /sys/firmware/opal/msglog", console=console)

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -34,28 +34,36 @@ IPMI package which contains all BMC related IPMI commands
 This class encapsulates all function which deals with the BMC over IPMI
 in OpenPower systems
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
+from builtins import str
+from builtins import range
+from builtins import object
 import time
 import subprocess
 import os
 import pexpect
 import sys
 import re
-import commands
+import subprocess
 
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
-from OpTestUtil import OpTestUtil
-import OpTestSystem
-from Exceptions import CommandFailed
-from Exceptions import BMCDisconnected
-import OPexpect
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
+from .OpTestUtil import OpTestUtil
+from . import OpTestSystem
+from .Exceptions import CommandFailed
+from .Exceptions import BMCDisconnected
+from . import OPexpect
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class IPMITool():
+class IPMITool(object):
     '''
     Run (locally) some command using ipmitool.
 
@@ -111,7 +119,7 @@ class IPMITool():
             output = cmd.communicate()[0]
             return output
 
-class pUpdate():
+class pUpdate(object):
     def __init__(self, method='lan', binary='pUpdate',
                  ip=None, username=None, password=None):
         self.method = 'lan'
@@ -163,7 +171,7 @@ class pUpdate():
             log.debug(output)
             return output
 
-class IPMIConsoleState():
+class IPMIConsoleState(object):
     DISCONNECTED = 0
     CONNECTED = 1
 
@@ -172,7 +180,7 @@ def set_system_to_UNKNOWN_BAD(system):
     system.set_state(OpTestSystem.OpSystemState.UNKNOWN_BAD)
     return s
 
-class IPMIConsole():
+class IPMIConsole(object):
     def __init__(self, ipmitool=None, logfile=sys.stdout, prompt=None,
             block_setup_term=None, delaybeforesend=None):
         self.logfile = logfile
@@ -322,7 +330,7 @@ class IPMIConsole():
     def run_command_ignore_fail(self, command, timeout=60, retry=0):
         return self.util.run_command_ignore_fail(self, command, timeout, retry)
 
-class OpTestIPMI():
+class OpTestIPMI(object):
     def __init__(self, i_bmcIP, i_bmcUser, i_bmcPwd, logfile=sys.stdout,
             host=None, delaybeforesend=None):
         self.cv_bmcIP = i_bmcIP
@@ -632,11 +640,11 @@ class OpTestIPMI():
         output = self.ipmitool.run('sel elist')
 
         if dump:
-            print "\n----------------------------------------------------------------------"
-            print "SELs"
-            print "----------------------------------------------------------------------"
-            print "{}".format(output)
-            print "----------------------------------------------------------------------"
+            print("\n----------------------------------------------------------------------")
+            print("SELs")
+            print("----------------------------------------------------------------------")
+            print("{}".format(output))
+            print("----------------------------------------------------------------------")
 
         return output
 

--- a/common/OpTestKeys.py
+++ b/common/OpTestKeys.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 
-class OpTestKeys():
+from builtins import object
+class OpTestKeys(object):
 
     UP      = '\x1b[A'
     DOWN    = '\x1b[B'

--- a/common/OpTestMambo.py
+++ b/common/OpTestMambo.py
@@ -21,7 +21,10 @@
 '''
 Support testing against Mambo simulator
 '''
+from __future__ import absolute_import
 
+from builtins import str
+from builtins import object
 import sys
 import time
 import pexpect
@@ -29,18 +32,18 @@ import subprocess
 import os
 
 from common.Exceptions import CommandFailed, ParameterCheck
-import OPexpect
-from OpTestUtil import OpTestUtil
+from . import OPexpect
+from .OpTestUtil import OpTestUtil
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class ConsoleState():
+class ConsoleState(object):
     DISCONNECTED = 0
     CONNECTED = 1
 
-class MamboConsole():
+class MamboConsole(object):
     '''
     A 'connection' to the Mambo Console involves *launching* Mambo.
     Closing a connection will *terminate* the Mambo process.
@@ -203,7 +206,7 @@ class MamboConsole():
     def mambo_enter(self):
         return self.util.mambo_enter(self)
 
-class MamboIPMI():
+class MamboIPMI(object):
     '''
     Mambo has fairly limited IPMI capability.
     '''
@@ -233,7 +236,7 @@ class MamboIPMI():
     def sys_set_bootdev_no_override(self):
         pass
 
-class OpTestMambo():
+class OpTestMambo(object):
     def __init__(self, mambo_binary=None,
                  mambo_initial_run_script=None,
                  mambo_autorun=None,

--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -17,6 +17,13 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import re
 import sys
 import time
@@ -28,18 +35,18 @@ import requests
 import cgi
 import os
 
-from OpTestSSH import OpTestSSH
-from OpTestBMC import OpTestBMC
-from Exceptions import HTTPCheck
-from Exceptions import CommandFailed
-from OpTestConstants import OpTestConstants as BMC_CONST
-import OpTestSystem
+from .OpTestSSH import OpTestSSH
+from .OpTestBMC import OpTestBMC
+from .Exceptions import HTTPCheck
+from .Exceptions import CommandFailed
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from . import OpTestSystem
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class HostManagement():
+class HostManagement(object):
     '''
     HostManagement Class
     OpenBMC methods to manage the Host
@@ -209,7 +216,7 @@ class HostManagement():
         for j in id_list:
             dict_item = {}
             dict_item['Id'] = str(json_data['data'][sel_dict.get(j)].get('Id'))
-            dict_item['Timestamp'] = datetime.datetime.fromtimestamp(int(str(json_data['data'][sel_dict.get(j)].get('Timestamp')))/1000).strftime("%Y-%m-%d %H:%M:%S")
+            dict_item['Timestamp'] = datetime.datetime.fromtimestamp(old_div(int(str(json_data['data'][sel_dict.get(j)].get('Timestamp'))),1000)).strftime("%Y-%m-%d %H:%M:%S")
             dict_item['Message'] = json_data['data'][sel_dict.get(j)].get('Message')
             dict_item['Description'] = json_data['data'][sel_dict.get(j)].get('Description')
             dict_item['Severity'] = json_data['data'][sel_dict.get(j)].get('Severity').split('.')[-1]
@@ -224,32 +231,32 @@ class HostManagement():
             dict_list.append(dict_item)
 
         if dump:
-            print "\n----------------------------------------------------------------------"
-            print "SELs"
-            print "----------------------------------------------------------------------"
+            print("\n----------------------------------------------------------------------")
+            print("SELs")
+            print("----------------------------------------------------------------------")
             if len(id_list) == 0:
-                print "SEL has no entries"
+                print("SEL has no entries")
             for k in dict_list:
-                print "Id          : {}".format(k.get('Id'))
-                print "Message     : {}".format(k.get('Message'))
-                print "Description : {}".format(k.get('Description'))
-                print "Timestamp   : {}".format(k.get('Timestamp'))
-                print "Severity    : {}".format(k.get('Severity'))
-                print "Resolved    : {}".format(k.get('Resolved'))
+                print("Id          : {}".format(k.get('Id')))
+                print("Message     : {}".format(k.get('Message')))
+                print("Description : {}".format(k.get('Description')))
+                print("Timestamp   : {}".format(k.get('Timestamp')))
+                print("Severity    : {}".format(k.get('Severity')))
+                print("Resolved    : {}".format(k.get('Resolved')))
                 if k.get('EventID') is not None:
-                    print "EventID     : {}".format(k.get('EventID'))
+                    print("EventID     : {}".format(k.get('EventID')))
                 if k.get('Procedure') is not None:
-                    print "Procedure   : {}".format(k.get('Procedure'))
+                    print("Procedure   : {}".format(k.get('Procedure')))
                 if k.get('esel') is not None:
-                    print "ESEL        : characters={}\n".format(len(k.get('esel')))
-                    print "Ruler        : 0123456789012345678901234567890123456789012345678901234567890123"
-                    print "-------------------------------------------------------------------------------"
+                    print("ESEL        : characters={}\n".format(len(k.get('esel'))))
+                    print("Ruler        : 0123456789012345678901234567890123456789012345678901234567890123")
+                    print("-------------------------------------------------------------------------------")
                     for j in range(0, len(k.get('esel')), 64):
-                        print "{:06d}-{:06d}: {}".format(j, j+63, k.get('esel')[j:j+64])
+                        print("{:06d}-{:06d}: {}".format(j, j+63, k.get('esel')[j:j+64]))
                 else:
-                    print "ESEL        : None"
-                print "\n"
-            print "----------------------------------------------------------------------"
+                    print("ESEL        : None")
+                print("\n")
+            print("----------------------------------------------------------------------")
         # sample id_list ['81', '82', '83', '84']
         log.debug("id_list={}".format(id_list))
         log.debug("dict_list={}".format(dict_list))
@@ -506,9 +513,9 @@ class HostManagement():
                                                headers=octet_hdr,
                                                data=fileload)
             if r.status_code != 200:
-                print r.headers
-                print r.text
-                print r
+                print(r.headers)
+                print(r.text)
+                print(r)
 
     def get_image_priority(self, id, minutes=BMC_CONST.HTTP_RETRY):
         '''
@@ -925,7 +932,7 @@ class HostManagement():
         '''
         self.configure_tpm_enable(0)
 
-class OpTestOpenBMC():
+class OpTestOpenBMC(object):
     def __init__(self, ip=None, username=None, password=None, ipmi=None,
             rest_api=None, logfile=sys.stdout,
             check_ssh_keys=False, known_hosts_file=None):

--- a/common/OpTestQemu.py
+++ b/common/OpTestQemu.py
@@ -21,7 +21,11 @@
 """
 Support testing against Qemu simulator
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import str
+from builtins import object
 import atexit
 import sys
 import time
@@ -31,19 +35,19 @@ import tempfile
 import os
 
 from common.Exceptions import CommandFailed
-import OPexpect
-from OpTestUtil import OpTestUtil
+from . import OPexpect
+from .OpTestUtil import OpTestUtil
 import OpTestConfiguration
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class ConsoleState():
+class ConsoleState(object):
     DISCONNECTED = 0
     CONNECTED = 1
 
-class QemuConsole():
+class QemuConsole(object):
     """
     A 'connection' to the Qemu Console involves *launching* qemu.
     Closing a connection will *terminate* the qemu process.
@@ -199,7 +203,7 @@ class QemuConsole():
     def run_command_ignore_fail(self, command, timeout=60, retry=0):
         return self.util.run_command_ignore_fail(self, command, timeout, retry)
 
-class QemuIPMI():
+class QemuIPMI(object):
     """
     Qemu has fairly limited IPMI capability, and we probably need to
     extend the capability checks so that more of the IPMI test suite
@@ -232,7 +236,7 @@ class QemuIPMI():
     def sys_set_bootdev_no_override(self):
         pass
 
-class OpTestQemu():
+class OpTestQemu(object):
     def __init__(self, conf=None, qemu_binary=None, pnor=None, skiboot=None,
                  kernel=None, initramfs=None, cdrom=None,
                  logfile=sys.stdout):

--- a/common/OpTestSOL.py
+++ b/common/OpTestSOL.py
@@ -25,6 +25,7 @@ This adds a new multithreaded library with having different
 variants of thread based SSH/SOL session runs, each thread logs
 to a different log file.
 '''
+from __future__ import absolute_import
 
 import random
 import unittest
@@ -34,9 +35,9 @@ import pexpect
 import os
 
 import OpTestConfiguration
-from OpTestSystem import OpSystemState
-from Exceptions import CommandFailed
-from OpTestIPMI import IPMIConsoleState
+from .OpTestSystem import OpSystemState
+from .Exceptions import CommandFailed
+from .OpTestIPMI import IPMIConsoleState
 
 import logging
 from logging.handlers import RotatingFileHandler

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -17,6 +17,10 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import absolute_import
+from builtins import str
+from builtins import hex
+from builtins import object
 import re
 import sys
 import os
@@ -27,18 +31,18 @@ import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-from Exceptions import CommandFailed, SSHSessionDisconnected
-from OpTestUtil import OpTestUtil
-import OpTestSystem
+from .Exceptions import CommandFailed, SSHSessionDisconnected
+from .OpTestUtil import OpTestUtil
+from . import OpTestSystem
 try:
     from common import OPexpect
 except ImportError:
-    import OPexpect
+    from . import OPexpect
 
 sudo_responses = ["not in the sudoers",
                   "incorrect password"]
 
-class ConsoleState():
+class ConsoleState(object):
     DISCONNECTED = 0
     CONNECTED = 1
 
@@ -47,7 +51,7 @@ def set_system_to_UNKNOWN_BAD(system):
     system.set_state(OpTestSystem.OpSystemState.UNKNOWN_BAD)
     return s
 
-class OpTestSSH():
+class OpTestSSH(object):
     def __init__(self, host, username, password, logfile=sys.stdout, port=22,
             prompt=None, check_ssh_keys=False, known_hosts_file=None,
             block_setup_term=None, delaybeforesend=None, use_parent_logger=True):

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -30,6 +30,10 @@
 #  This class encapsulates all interfaces and classes required to do end to end
 #  automated flashing and testing of OpenPower systems.
 
+from __future__ import absolute_import
+from builtins import hex
+from builtins import range
+from builtins import object
 import time
 import subprocess
 import pexpect
@@ -37,24 +41,24 @@ import socket
 import errno
 import unittest
 
-import OpTestIPMI # circular dependencies, use package
-import OpTestQemu
-import OpTestMambo
-from OpTestFSP import OpTestFSP
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
-import OpTestHost
-from OpTestUtil import OpTestUtil
-from OpTestSSH import ConsoleState as SSHConnectionState
-from Exceptions import HostbootShutdown, WaitForIt, RecoverFailed, UnknownStateTransition
-from Exceptions import ConsoleSettings, UnexpectedCase, StoppingSystem, HTTPCheck
-from OpTestSSH import OpTestSSH
+from . import OpTestIPMI # circular dependencies, use package
+from . import OpTestQemu
+from . import OpTestMambo
+from .OpTestFSP import OpTestFSP
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
+from . import OpTestHost
+from .OpTestUtil import OpTestUtil
+from .OpTestSSH import ConsoleState as SSHConnectionState
+from .Exceptions import HostbootShutdown, WaitForIt, RecoverFailed, UnknownStateTransition
+from .Exceptions import ConsoleSettings, UnexpectedCase, StoppingSystem, HTTPCheck
+from .OpTestSSH import OpTestSSH
 
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class OpSystemState():
+class OpSystemState(object):
     '''
     This class is used as an enum as to what state op-test *thinks* the host is in.
     These states are used to drive a state machine in OpTestSystem.
@@ -194,7 +198,7 @@ class OpTestSystem(object):
     def hostboot_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         self.state = OpSystemState.UNKNOWN_BAD
         self.stop = 1
@@ -203,7 +207,7 @@ class OpTestSystem(object):
     def login_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         log.warning("\n\n *** OpTestSystem found the login prompt \"{}\" but this is unexpected, we will retry\n\n".format(kwargs['value']))
         # raise the WaitForIt exception to be bubbled back to recycle early rather than having to wait the full loop_max
@@ -212,7 +216,7 @@ class OpTestSystem(object):
     def petitboot_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         log.warning("\n\n *** OpTestSystem found the petitboot prompt \"{}\" but this is unexpected, we will retry\n\n".format(kwargs['value']))
         # raise the WaitForIt exception to be bubbled back to recycle early rather than having to wait the full loop_max
@@ -221,7 +225,7 @@ class OpTestSystem(object):
     def guard_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         self.sys_sel_elist(dump=True)
         guard_exception = UnexpectedCase(state=self.state, message="We hit the guard_callback value={}, manually restart the system".format(kwargs['value']))
@@ -232,7 +236,7 @@ class OpTestSystem(object):
     def xmon_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         xmon_check_r = kwargs['my_r']
         xmon_value = kwargs['value']
@@ -272,7 +276,7 @@ class OpTestSystem(object):
     def dracut_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 kwargs[key] = default_vals[key]
         try:
             sys_pty = self.console.get_console()
@@ -289,7 +293,7 @@ class OpTestSystem(object):
     def skiboot_callback(self, **kwargs):
         default_vals = {'my_r': None, 'value': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         self.sys_sel_elist(dump=True)
         skiboot_exception = UnexpectedCase(state=self.state, message="We hit the skiboot_callback value={}, manually restart the system".format(kwargs['value']))
@@ -489,7 +493,7 @@ class OpTestSystem(object):
     def wait_for_it(self, **kwargs):
         default_vals = {'expect_dict': None, 'refresh': 1, 'buffer_kicker': 1, 'loop_max': 8, 'threshold': 1, 'reconnect': 1, 'fresh_start' : 1, 'last_try': 1, 'timeout': 5}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         base_seq = [pexpect.TIMEOUT, pexpect.EOF]
         expect_seq = list(base_seq) # we want a *copy*
@@ -564,7 +568,7 @@ class OpTestSystem(object):
     def check_it(self, **kwargs):
         default_vals = {'my_r': None, 'check_base_seq': None, 'check_expect_seq': None, 'check_expect_dict': None}
         for key in default_vals:
-          if key not in kwargs.keys():
+          if key not in list(kwargs.keys()):
             kwargs[key] = default_vals[key]
         check_r = kwargs['my_r']
         check_expect_seq = kwargs['check_expect_seq']

--- a/common/OpTestThread.py
+++ b/common/OpTestThread.py
@@ -25,6 +25,7 @@ This adds a new multithreaded library with having different
 variants of thread based SSH/SOL session runs, each thread logs
 to a different log file.
 '''
+from __future__ import absolute_import
 
 import random
 import unittest
@@ -33,10 +34,10 @@ import threading
 import pexpect
 
 import OpTestConfiguration
-from OpTestSystem import OpSystemState
-from OpTestConstants import OpTestConstants as BMC_CONST
-from Exceptions import CommandFailed
-from OpTestIPMI import IPMIConsoleState
+from .OpTestSystem import OpSystemState
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .Exceptions import CommandFailed
+from .OpTestIPMI import IPMIConsoleState
 
 import logging
 import OpTestLogger
@@ -104,7 +105,7 @@ class OpSSHThreadLinearVar2(threading.Thread):
         execution_time = time.time() + 60*torture_time,
         log.debug("Starting %s for new SSH thread %s" % (threadName, cmd_dic))
         while True:
-            for cmd, tm in cmd_dic.iteritems():
+            for cmd, tm in cmd_dic.items():
                 if ignore_fail:
                     try:
                         self.c.run_command(cmd)

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -24,6 +24,14 @@
 #
 # IBM_PROLOG_END_TAG
 
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
+from builtins import str
+from builtins import range
+from builtins import object
 import sys
 import os
 import datetime
@@ -39,20 +47,20 @@ import select
 import time
 import pty
 import pexpect
-import commands
+import subprocess
 import requests
 import traceback
 from requests.adapters import HTTPAdapter
 #from requests.packages.urllib3.util import Retry
-from httplib import HTTPConnection
+from http.client import HTTPConnection
 #HTTPConnection.debuglevel = 1 # this will print some additional info to stdout
 import urllib3 # setUpChildLogger enables integrated logging with op-test
 import json
 
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
-from Exceptions import CommandFailed, RecoverFailed, ConsoleSettings
-from Exceptions import HostLocker, AES, ParameterCheck, HTTPCheck, UnexpectedCase
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
+from .Exceptions import CommandFailed, RecoverFailed, ConsoleSettings
+from .Exceptions import HostLocker, AES, ParameterCheck, HTTPCheck, UnexpectedCase
 
 import logging
 import OpTestLogger
@@ -61,7 +69,7 @@ log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 sudo_responses = ["not in the sudoers",
                   "incorrect password"]
 
-class OpTestUtil():
+class OpTestUtil(object):
 
     def __init__(self, conf=None):
         self.conf = conf
@@ -337,7 +345,7 @@ class OpTestUtil():
       if environments is None:
         return
       sorted_env_list = sorted(environments, key=self.get_env_name)
-      print "--------------------------------------------------------------------------------"
+      print("--------------------------------------------------------------------------------")
       for env in sorted_env_list:
         print ("--aes-search-args Environment_Name='{}' Environment_EnvId={} "
           "Group_Name='{}' Group_GroupId={} Environment_State={} <res_id={} "
@@ -345,14 +353,14 @@ class OpTestUtil():
           .format(env['name'], env['env_id'], env['group']['name'],
           env['group']['group_id'], env['state'], env['res_id'],
           env['res_email'], env['res_length'], ))
-      print "--------------------------------------------------------------------------------"
+      print("--------------------------------------------------------------------------------")
       print ("\nHELPERS   --aes-search-args Server_VersionName=witherspoon|boston|habanero|zz|tuleta"
              "|palmetto|brazos|fleetwood|p8dtu|p9dsu|zaius|stratton|firestone|garrison|romulus|alpine")
-      print "          --aes-search-args Server_HardwarePlatform=POWER8|POWER9|openpower"
-      print "          --aes-search-args Group_Name=op-test"
-      print "          --aes-search-args Environment_State=A|R|M|X|H|E"
-      print "A=Available R=Reserved M=Maintenance X=Offline H=HealthCheck E=Exclusive"
-      print "AES Environments found = {}".format(len(sorted_env_list))
+      print("          --aes-search-args Server_HardwarePlatform=POWER8|POWER9|openpower")
+      print("          --aes-search-args Group_Name=op-test")
+      print("          --aes-search-args Environment_State=A|R|M|X|H|E")
+      print("A=Available R=Reserved M=Maintenance X=Offline H=HealthCheck E=Exclusive")
+      print("AES Environments found = {}".format(len(sorted_env_list)))
 
 
     def aes_release_reservation(self, res_id=None, env=None):
@@ -554,7 +562,7 @@ class OpTestUtil():
             "for server record, we either have no server record or more "
             "than one, check FSPs and BMCs")
 
-        for key, value in aes_mappings.items():
+        for key, value in list(aes_mappings.items()):
           if env['servers'][0].get(key) is not None and env['servers'][0].get(key) != '':
             if key == 'version_name':
               args_dict[aes_mappings[key]] = version_mappings.get(env['servers'][0][key].lower())
@@ -675,7 +683,7 @@ class OpTestUtil():
         hostlocker_comment = []
         hostlocker_comment = host['comment'].splitlines()
 
-        for key in args_dict.keys():
+        for key in list(args_dict.keys()):
             for i in range(len(hostlocker_comment)):
                 if key + ':'  in hostlocker_comment[i]:
                     args_dict[key] = re.sub(key + ':', "", hostlocker_comment[i]).strip()
@@ -894,7 +902,7 @@ class OpTestUtil():
         cmd = "ping -c 1 " + i_ip + " 1> /dev/null; echo $?"
         count = 0
         while count < 500:
-            output = commands.getstatusoutput(cmd)
+            output = subprocess.getstatusoutput(cmd)
             if output[1] != '0':
                 log.debug("IP %s Comes down" % i_ip)
                 break
@@ -1736,7 +1744,7 @@ class Server(object):
                         'files' : None, 'stream' : False,
                         'verify' : False, 'headers' : None}
         for key in default_vals:
-            if key not in kwargs.keys():
+            if key not in list(kwargs.keys()):
                 kwargs[key] = default_vals[key]
 
         command_dict = { 'get'    : self.session.get,

--- a/common/OpTestWeb.py
+++ b/common/OpTestWeb.py
@@ -24,14 +24,17 @@
 #
 # IBM_PROLOG_END_TAG
 
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import object
 import time
 import subprocess
 import os
 import pexpect
 import unittest
 
-from OpTestConstants import OpTestConstants as BMC_CONST
-from OpTestError import OpTestError
+from .OpTestConstants import OpTestConstants as BMC_CONST
+from .OpTestError import OpTestError
 
 ## @package OpTestWeb
 #  Contains all BMC related Web tools
@@ -39,7 +42,7 @@ from OpTestError import OpTestError
 #  This class encapsulates all function which deals with the BMC Using Web GUI
 #  in OpenPower systems
 #
-class OpTestWeb():
+class OpTestWeb(object):
 
     ##
     # @brief Initialize OpTestWeb Object

--- a/common/util/web/FWUpdatePage.py
+++ b/common/util/web/FWUpdatePage.py
@@ -24,9 +24,13 @@
 #
 # IBM_PROLOG_END_TAG
 
-from Page import Page
-from seleniumimports import *
-from BmcPageConstants import BmcPageConstants
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
+from builtins import object
+from .Page import Page
+from .seleniumimports import *
+from .BmcPageConstants import BmcPageConstants
 from selenium.webdriver.support.ui import Select
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
@@ -43,7 +47,7 @@ import time
 # @brief: This class manages interaction with FW Update
 # menus and webpages
 #
-class FWUpdatePage():
+class FWUpdatePage(object):
 
     ##
     #  @brief Constructor - Takes a pointer to BMC WebDriver

--- a/common/util/web/LoginPage.py
+++ b/common/util/web/LoginPage.py
@@ -24,13 +24,16 @@
 #
 # IBM_PROLOG_END_TAG
 
-from Page import Page
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import object
+from .Page import Page
 from engine.FWObject import FWObject
-from BmcPageConstants import BmcPageConstants
+from .BmcPageConstants import BmcPageConstants
 from connection.common.FWConnection import FWConnection
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
-from seleniumimports import *
+from .seleniumimports import *
 
 ##
 # @file: LoginPage.py
@@ -41,7 +44,7 @@ from seleniumimports import *
 # LoginPage # @brief: This class manages interaction with BMC Login
 #                      webpage (no telnet and ssh)
 #
-class LoginPage():
+class LoginPage(object):
     ##
     #  @brief Constructor for Login_Page class
     #  @param Page - Handle to the BMC Web-browswer

--- a/common/util/web/MaintenancePage.py
+++ b/common/util/web/MaintenancePage.py
@@ -24,9 +24,12 @@
 #
 # IBM_PROLOG_END_TAG
 
-from Page import Page
-from seleniumimports import *
-from BmcPageConstants import BmcPageConstants
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import object
+from .Page import Page
+from .seleniumimports import *
+from .BmcPageConstants import BmcPageConstants
 from selenium.webdriver.support.ui import Select
 from OpTestConstants import OpTestConstants as BMC_CONST
 from OpTestError import OpTestError
@@ -41,7 +44,7 @@ import time
 #  Maintenance_Page
 #  @brief: This class provides interface to Maintenance menu and other page interactions
 #
-class MaintenancePage():
+class MaintenancePage(object):
     OptionDict = {
         'IPMI':'_chkPrsrvStatus3',
         'NETWORK':'_chkPrsrvStatus4'

--- a/op-test
+++ b/op-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/testcases/AT24driver.py
+++ b/testcases/AT24driver.py
@@ -37,6 +37,7 @@ This driver has following functionalities:
   driver is capable of reading and programming the data to these devices.
 '''
 
+from builtins import str
 import time
 import subprocess
 import re
@@ -79,7 +80,7 @@ class AT24driver(I2C, unittest.TestCase):
                 "CONFIG_EEPROM_AT24": "at24"}
 
         try:
-            for (c, m) in mods.items():
+            for (c, m) in list(mods.items()):
                 self.cv_HOST.host_load_module_based_on_config(l_kernel, c, m)
         except KernelConfigNotSet as ns:
             self.assertTrue(False, str(ns))

--- a/testcases/BMCResetTorture.py
+++ b/testcases/BMCResetTorture.py
@@ -31,9 +31,12 @@ BMCResetTorture
 This testcase does BMC reset torture in different scenarios.
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 import time
 import subprocess
-import commands
+import subprocess
 import re
 import sys
 

--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -27,7 +27,10 @@ BMC implementation we've ever thrown it at. Since we're highly reliant
 on the BMC providing a reliable host console, if these tests fail at all,
 then we're likely going to get spurious failures elsewhere in the test suite.
 '''
+from __future__ import division
 
+from builtins import object
+from past.utils import old_div
 import unittest
 import pexpect
 import time
@@ -42,7 +45,7 @@ import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 
-class Console():
+class Console(object):
     bs = 1024
     count = 8
 
@@ -72,7 +75,7 @@ class Console():
                 pass
             else:
                 raise cf
-        expected = adjustment + (count * bs) / 16
+        expected = adjustment + old_div((count * bs), 16)
         self.assertTrue(len(zeros) == expected,
                         "Unexpected length of zeros {} != {}".format(
                             len(zeros), expected))

--- a/testcases/CpuHotPlug.py
+++ b/testcases/CpuHotPlug.py
@@ -35,6 +35,8 @@ we put cores/threads into when we hot unplug them.
 # FIXME: Add a smaller version of this test to the normal host test suite
 # FIXME: Work out a way to add this to the skiroot test suite.
 
+from builtins import str
+from builtins import range
 import unittest
 
 import OpTestConfiguration
@@ -64,7 +66,7 @@ class CpuHotPlug(unittest.TestCase):
         self.c.run_command("uname -a")
         self.c.run_command("cat /etc/os-release")
         self.num_avail_cores = self.cv_HOST.host_get_core_count()
-        smt_range = ["on", "off"] + range(1, self.cv_HOST.host_get_smt()+1)
+        smt_range = ["on", "off"] + list(range(1, self.cv_HOST.host_get_smt()+1))
         log.debug("Possible smt values: %s" % smt_range)
         for smt in smt_range:
             self.c.run_command("ppc64_cpu --smt=%s" % str(smt))

--- a/testcases/DeviceTreeValidation.py
+++ b/testcases/DeviceTreeValidation.py
@@ -31,6 +31,8 @@ Check a bunch of device tree properties and structure for validity,
 and compare device tree in host and skiroot environments.
 '''
 
+from builtins import zip
+from builtins import str
 import unittest
 import re
 import struct
@@ -332,8 +334,8 @@ class DeviceTreeValidation(unittest.TestCase):
                         skipped_props += 1
                         continue
                     unified_output = difflib.unified_diff(
-                        filter(None, prop_val_pair_skiroot[prop]),
-                        filter(None, prop_val_pair_host[prop]),
+                        [_f for _f in prop_val_pair_skiroot[prop] if _f],
+                        [_f for _f in prop_val_pair_host[prop] if _f],
                         fromfile="skiroot",
                         tofile="host",
                         lineterm="")

--- a/testcases/DeviceTreeWarnings.py
+++ b/testcases/DeviceTreeWarnings.py
@@ -29,6 +29,7 @@ DeviceTreeWarnings
 Check for any warnings from tools such as ``dtc`` in our device tree.
 '''
 
+from builtins import object
 import unittest
 import re
 
@@ -38,7 +39,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 
 
-class DeviceTreeWarnings():
+class DeviceTreeWarnings(object):
     '''
     Look at the warnings from ``dtc``, filtering out any known issues.
     '''
@@ -67,7 +68,7 @@ class DeviceTreeWarnings():
             fre = re.compile(f)
             log_entries = [l for l in log_entries if not fre.search(l)]
 
-        msg = '\n'.join(filter(None, log_entries))
+        msg = '\n'.join([_f for _f in log_entries if _f])
         self.assertTrue(len(log_entries) == 0,
                         "Warnings/Errors in Device Tree:\n{}".format(msg))
 

--- a/testcases/EMStress.py
+++ b/testcases/EMStress.py
@@ -23,6 +23,10 @@ EM Stress tests
 ---------------
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
 import unittest
 import time
 import threading
@@ -122,7 +126,7 @@ class RuntimeEMStress(unittest.TestCase, OpTestEM):
         # CPU Hotplug torture
         torture_time = self.torture_time
         num_avail_cores = self.host.host_get_core_count()
-        smt_range = ["on", "off"] + range(1, self.host.host_get_smt()+1)
+        smt_range = ["on", "off"] + list(range(1, self.host.host_get_smt()+1))
         log.debug("Possible smt values: %s" % smt_range)
         cmd_list = []
         for smt in smt_range:

--- a/testcases/EPOW.py
+++ b/testcases/EPOW.py
@@ -41,10 +41,14 @@ This module tests the EPOW feature incase of FSP systems.
    Simualate temperatures less than EPOW3 threshold
    and check whether Host OS is alive or not.
 '''
+from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import hex
+from builtins import range
 import time
-import subprocess
-import commands
 import re
 import sys
 import pexpect
@@ -84,7 +88,7 @@ class EPOWBase(unittest.TestCase):
         var = y[1] + "s" + y[0] + "u"
 
         self.proc_gen = self.cv_HOST.host_get_proc_gen(console=1)
-        print self.proc_gen
+        print(self.proc_gen)
         if self.proc_gen in ["POWER8", "POWER8E"]:
             file = '/opt/fips/components/engd/power_management_tul_%s.def' % (var)
         elif self.proc_gen in ["POWER9"]:
@@ -138,7 +142,7 @@ class EPOWBase(unittest.TestCase):
                 res = pty.before
                 log.debug(pty.after)
                 log.debug("System got graceful shutdown")
-        except pexpect.TIMEOUT, e:
+        except pexpect.TIMEOUT as e:
             log.debug("System is in active state")
             log.debug(pty.before)
 

--- a/testcases/I2C.py
+++ b/testcases/I2C.py
@@ -30,6 +30,8 @@ This class will test functionality of following drivers:
 I2C Driver(Inter-Integrated Circuit) driver
 '''
 
+from builtins import str
+from builtins import object
 import time
 import subprocess
 import re
@@ -55,7 +57,7 @@ class I2CDetectUnsupported(Exception):
     pass
 
 
-class I2C():
+class I2C(object):
     '''
     Base class for I2C tests
     '''
@@ -88,7 +90,7 @@ class I2C():
                 "CONFIG_EEPROM_AT24": "at24"}
 
         try:
-            for (c, m) in mods.items():
+            for (c, m) in list(mods.items()):
                 self.cv_HOST.host_load_module_based_on_config(l_kernel, c, m)
         except KernelConfigNotSet as ns:
             self.assertTrue(False, str(ns))

--- a/testcases/KernelLog.py
+++ b/testcases/KernelLog.py
@@ -28,6 +28,7 @@ rather than a firmware issue).
 
 '''
 
+from builtins import object
 import unittest
 import re
 
@@ -40,7 +41,7 @@ import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class KernelLog():
+class KernelLog(object):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.cv_HOST = conf.host()
@@ -145,7 +146,7 @@ class KernelLog():
             fre = re.compile(f)
             log_entries = [l for l in log_entries if not fre.search(l)]
 
-        msg = '\n'.join(filter(None, log_entries))
+        msg = '\n'.join([_f for _f in log_entries if _f])
         self.assertTrue(len(log_entries) == 0,
                         "Warnings/Errors in Kernel log:\n%s" % msg)
 

--- a/testcases/OpTestEEH.py
+++ b/testcases/OpTestEEH.py
@@ -34,9 +34,10 @@ This testcase basically tests all OPAL EEH Error injection tests.
 - frozen PE
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 import time
-import subprocess
-import commands
 import re
 import sys
 import os
@@ -477,7 +478,7 @@ class OpTestEEHbasic_frozen_pe(OpTestEEH):
         # Ex: echo "PE_number:<0,1>:<function>:0:0" > /sys/kernel/debug/powerpc/PCIxxxx/err_injct
         # echo 2:0:4:0:0 > /sys/kernel/debug/powerpc/PCI0001/err_injct && lspci -ns 0001:0c:00.0; echo $?
         # Inject error on every PE
-        for pe, addr in pe_dic.iteritems():
+        for pe, addr in pe_dic.items():
             count = 0
             recover = True
             for e in ERROR:
@@ -555,7 +556,7 @@ class OpTestEEHmax_frozen_pe(OpTestEEH):
         # Ex: echo "PE_number:<0,1>:<function>:0:0" > /sys/kernel/debug/powerpc/PCIxxxx/err_injct
         # echo 2:0:4:0:0 > /sys/kernel/debug/powerpc/PCI0001/err_injct && lspci -ns 0001:0c:00.0; echo $?
         # Inject error on every PE
-        for pe, addr in pe_dic.iteritems():
+        for pe, addr in pe_dic.items():
             count = 0
             recover = True
             for e in ERROR:

--- a/testcases/OpTestEM.py
+++ b/testcases/OpTestEM.py
@@ -35,7 +35,11 @@ This class will test the functionality of following drivers:
 1. powernv cpuidle driver
 2. powernv cpufreq driver
 '''
+from __future__ import division
 
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import time
 import subprocess
 import re
@@ -55,7 +59,7 @@ import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
-class OpTestEM():
+class OpTestEM(object):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.cv_HOST = conf.host()
@@ -164,11 +168,11 @@ class OpTestEM():
                 freq[m.group(1)] = int(decimal.Decimal(m.group(2)) * 1000000)
         # Frequencies are in KHz
         log.debug(repr(freq))
-        delta = int(i_freq) / (100)
+        delta = old_div(int(i_freq), (100))
         log.debug("# Set %d, Measured %d, Allowed Delta %d" % (int(i_freq),freq["avg"],delta))
-        self.assertAlmostEqual(freq["min"], freq["max"], delta=(freq["avg"]/100),
+        self.assertAlmostEqual(freq["min"], freq["max"], delta=(old_div(freq["avg"],100)),
                                msg="ppc64_cpu measured CPU Frequency differs between min/max when frequency set explicitly")
-        self.assertAlmostEqual(freq["avg"], freq["max"], delta=(freq["avg"]/100),
+        self.assertAlmostEqual(freq["avg"], freq["max"], delta=(old_div(freq["avg"],100)),
                                msg="ppc64_cpu measured CPU Frequency differs between avg/max when frequency set explicitly")
 
 
@@ -198,7 +202,7 @@ class OpTestEM():
             freq_list = i_freq
 
         for freq in freq_list:
-            delta = int(freq) / (100)
+            delta = old_div(int(freq), (100))
             try:
                 self.assertAlmostEqual(int(cur_freq[0]), int(freq), delta=delta,
                                        msg="CPU frequency not changed to %s" % i_freq)
@@ -478,7 +482,7 @@ class cpu_boost_freqs_host(OpTestEM, DeviceTreeValidation, unittest.TestCase):
 
         achieved = False
         for freq in freq_list:
-            delta = int(freq) / (100)
+            delta = old_div(int(freq), (100))
             try:
                 self.assertAlmostEqual(int(freq), achieved_freq, delta=delta,
                                        msg="Set and measured CPU frequency differ too greatly")
@@ -604,7 +608,7 @@ class cpu_idle_states_host(OpTestEM, unittest.TestCase):
                     success += 0.5
                 total += 1
             log.debug("CPUs entered idle state %s for %d/%d of the times" % (idle_state_names[i], success, total))
-            self.assertGreater(success/total, 0.95, "CPUs entered idle state %s for %d/%d of the times" % (idle_state_names[i], success, total))
+            self.assertGreater(old_div(success,total), 0.95, "CPUs entered idle state %s for %d/%d of the times" % (idle_state_names[i], success, total))
             self.disable_idle_state(i)
 
         # Remove added temptext.txt file. Idle states are re-enabled during tearDown

--- a/testcases/OpTestExample.py
+++ b/testcases/OpTestExample.py
@@ -25,6 +25,9 @@ This test case is meant to show a few best practices for writing a test case
 for `op-test`.
 '''
 
+from builtins import map
+from builtins import str
+from builtins import range
 import unittest
 import logging
 
@@ -121,7 +124,7 @@ class OpTestExample(unittest.TestCase):
 
       try:
         for xkey, xcommand in sorted(op_dictionary.items()):
-          xresults[xkey] = list(filter(None, self.my_console.run_command(xcommand)))
+          xresults[xkey] = list([_f for _f in self.my_console.run_command(xcommand) if _f])
 
         for xkey, xvalue in sorted(xresults.items()):
           log.debug('\nCommand Run: "{}"\n{}'.format(op_dictionary[xkey], '\n'.join(xresults[xkey])), extra=xresults)
@@ -130,7 +133,7 @@ class OpTestExample(unittest.TestCase):
         self.fail(str(op_pxssh))
       except CommandFailed as xe:
         my_x = {x:xe.output[x] for x in range(len(xe.output))}
-        log.debug('\n******************************\nCommand Failed: \n{}\n******************************'.format('\n'.join(my_x[y] for y,z in my_x.items())), extra=my_x)
+        log.debug('\n******************************\nCommand Failed: \n{}\n******************************'.format('\n'.join(my_x[y] for y,z in list(my_x.items()))), extra=my_x)
         log.debug('\nExitcode {}'.format(xe))
       except Exception as func_e:
         self.fail('OPDemoFunc Exception handler {}'.format(func_e))
@@ -167,7 +170,7 @@ def skiroot_suite():
        Tests run in order
     '''
     tests = ['PetitbootVersions']
-    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+    return unittest.TestSuite(list(map(SkirootBasicCheck, tests)))
 
 def skiroot_full_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -175,7 +178,7 @@ def skiroot_full_suite():
        Tests run in order
     '''
     tests = ['PetitbootVersions', 'OPMisc', 'OPComboTest']
-    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+    return unittest.TestSuite(list(map(SkirootBasicCheck, tests)))
 
 def host_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -183,7 +186,7 @@ def host_suite():
        Tests run in order
     '''
     tests = ['HostVersions']
-    return unittest.TestSuite(map(HostBasicCheck, tests))
+    return unittest.TestSuite(list(map(HostBasicCheck, tests)))
 
 def host_full_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -191,4 +194,4 @@ def host_full_suite():
        Tests run in order
     '''
     tests = ['HostVersions', 'PetitbootVersions', 'OPComboTest']
-    return unittest.TestSuite(map(HostBasicCheck, tests))
+    return unittest.TestSuite(list(map(HostBasicCheck, tests)))

--- a/testcases/OpTestHostboot.py
+++ b/testcases/OpTestHostboot.py
@@ -24,6 +24,7 @@ OpTestHostboot: Hostboot checks
 Perform various hostboot validations and checks
 '''
 
+from builtins import map
 import unittest
 import logging
 import pexpect
@@ -160,7 +161,7 @@ def skiroot_suite():
        Tests run in order
     '''
     tests = ['PetitbootChecks']
-    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+    return unittest.TestSuite(list(map(SkirootBasicCheck, tests)))
 
 def skiroot_full_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -168,7 +169,7 @@ def skiroot_full_suite():
        Tests run in order
     '''
     tests = ['PetitbootChecks']
-    return unittest.TestSuite(map(SkirootBasicCheck, tests))
+    return unittest.TestSuite(list(map(SkirootBasicCheck, tests)))
 
 def host_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -176,7 +177,7 @@ def host_suite():
        Tests run in order
     '''
     tests = ['HostChecks']
-    return unittest.TestSuite(map(HostBasicCheck, tests))
+    return unittest.TestSuite(list(map(HostBasicCheck, tests)))
 
 def host_full_suite():
     '''Function used to prepare a test suite (see op-test)
@@ -184,4 +185,4 @@ def host_full_suite():
        Tests run in order
     '''
     tests = ['HostChecks']
-    return unittest.TestSuite(map(HostBasicCheck, tests))
+    return unittest.TestSuite(list(map(HostBasicCheck, tests)))

--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -37,10 +37,13 @@ This class will test the functionality of following commands
    mc, pef, power, raw, sdr, sel, sensor, session, user
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import object
 import time
-import subprocess
 import re
-import commands
 import sys
 
 from common.OpTestConstants import OpTestConstants as BMC_CONST
@@ -187,7 +190,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase,unittest.TestCase):
             "diag" : "Force Boot from Diagnostic Partition",
             "floppy" : "Force Boot from Floppy/primary removable media",
         }
-        for bootdev,ipmiresponse in boot_devices.iteritems():
+        for bootdev,ipmiresponse in boot_devices.items():
             try:
                 try:
                     r = c.run_command(self.ipmi_method + 'chassis bootdev %s' % (bootdev))

--- a/testcases/OpTestMtdPnorDriver.py
+++ b/testcases/OpTestMtdPnorDriver.py
@@ -37,10 +37,12 @@ Test MTD PNOR Driver package for OpenPower testing.
    I *severely* doubt this test case currently works as intended.
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import time
-import subprocess
 import re
-import commands
+import subprocess
 
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
@@ -117,32 +119,32 @@ class OpTestMtdPnorDriver(unittest.TestCase):
         # Getting the /tmp/pnor file into local x86 machine
         l_path = "/tmp/"
         self.util.copyFilesToDest(l_path, self.host_user, self.host_ip, l_file, self.host_Passwd)
-        l_list =  commands.getstatusoutput("ls -l %s" % l_path)
+        l_list =  subprocess.getstatusoutput("ls -l %s" % l_path)
         log.debug(l_list)
 
         l_workdir = "/tmp/ffs"
         # Remove existing /tmp/ffs directory
-        l_res = commands.getstatusoutput("rm -rf %s" % l_workdir)
+        l_res = subprocess.getstatusoutput("rm -rf %s" % l_workdir)
 
         # Clone latest ffs git repository in local x86 working machine
         l_cmd = "git clone   https://github.com/open-power/ffs/ %s" % l_workdir
-        l_res = commands.getstatusoutput(l_cmd)
+        l_res = subprocess.getstatusoutput(l_cmd)
         self.assertEqual(int(l_res[0]), 0,
                 "Cloning ffs repository is failed")
 
         # Compile ffs repository to get fcp utility
         l_cmd = "cd %s/; autoreconf -i && ./configure && make" % l_workdir
-        l_res = commands.getstatusoutput(l_cmd)
+        l_res = subprocess.getstatusoutput(l_cmd)
         self.assertEqual(int(l_res[0]), 0, "Compiling fcp utility is failed")
 
         # Check existence of fcp utility in ffs repository, after compiling.
         l_cmd = "test -f %s/fcp/fcp" % l_workdir
-        l_res = commands.getstatusoutput(l_cmd)
+        l_res = subprocess.getstatusoutput(l_cmd)
         self.assertEqual(int(l_res[0]), 0, "Compiling fcp utility is failed")
 
         # Check the PNOR flash contents on an x86 machine using fcp utility
         l_cmd = "%s/fcp/fcp -o 0x0 -L %s" % (l_workdir, l_file)
-        l_res = commands.getstatusoutput(l_cmd)
+        l_res = subprocess.getstatusoutput(l_cmd)
         log.debug(l_res[1])
         self.assertEqual(int(l_res[0]), 0,
             "Getting the PNOR data using fcp utility failed")

--- a/testcases/OpTestOOBIPMI.py
+++ b/testcases/OpTestOOBIPMI.py
@@ -36,12 +36,14 @@ This class will test the functionality of following ipmi commands
    mc, pef, power, raw, sdr, sel, sensor, session, user
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import time
-import subprocess
 import re
 import os
 import sys
-import commands
+import subprocess
 
 from common.OpTestConstants import OpTestConstants as BMC_CONST
 import unittest
@@ -395,7 +397,7 @@ class OpTestOOBIPMI(OpTestOOBIPMIBase):
             "diag" : "Force Boot from Diagnostic Partition",
             "floppy" : "Force Boot from Floppy/primary removable media",
         }
-        for bootdev,ipmiresponse in boot_devices.iteritems():
+        for bootdev,ipmiresponse in boot_devices.items():
             cmd = "chassis bootdev %s" % bootdev
             self.run_ipmi_cmd(cmd)
             self.verify_bootdev(bootdev)
@@ -514,7 +516,7 @@ class OpTestOOBIPMI(OpTestOOBIPMIBase):
     #
     def test_fru_read(self):
         self.run_ipmi_cmd(BMC_CONST.IPMI_FRU_READ)
-        l_res = commands.getstatusoutput("hexdump -C file_fru")
+        l_res = subprocess.getstatusoutput("hexdump -C file_fru")
         if int(l_res[0]) == 0:
             log.debug(l_res[1])
         else:

--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -46,6 +46,8 @@ the applicable options per method.
 
 '''
 
+from builtins import map
+from builtins import object
 import unittest
 import logging
 import pexpect
@@ -233,8 +235,8 @@ class OpClassPCI(unittest.TestCase):
         Performs unified diff of two lists
         '''
         unified_output = difflib.unified_diff(
-            filter(None, listA),
-            filter(None, listB),
+            [_f for _f in listA if _f],
+            [_f for _f in listB if _f],
             fromfile=listA_name,
             tofile=listB_name,
             lineterm="")
@@ -363,7 +365,7 @@ class OpClassPCI(unittest.TestCase):
                 total_entries = [l for l in total_entries if not fre.search(l)]
             log.debug("P9DSU FILTERED OUT total_entries={}".format(total_entries))
 
-        msg = '\n'.join(filter(None, total_entries))
+        msg = '\n'.join([_f for _f in total_entries if _f])
         log.debug("total_entries={}".format(total_entries))
         self.assertTrue( len(total_entries) == 0, "pcie link down/timeout Errors in OPAL log:\n{}".format(msg))
 
@@ -513,7 +515,7 @@ class OpClassPCI(unittest.TestCase):
                 if obj:
                     pair[device] = obj.group(1)
         failure_list = {}
-        for device, phy_slot in pair.iteritems():
+        for device, phy_slot in pair.items():
             if root_pe in device:
                 continue
             index = "{}_{}".format(device, phy_slot)
@@ -569,7 +571,7 @@ class OpClassPCI(unittest.TestCase):
                 line = line.strip().split(' ')
                 device_ids.append(line[0])
 
-        class Device:
+        class Device(object):
             def __init__(self, device_info):
                 self.domain = ""
                 self.primary = ""
@@ -817,7 +819,7 @@ def skiroot_softboot_suite():
     --run testcases.OpTestPCI.skiroot_softboot_suite
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'compare_boot_devices']
-    return unittest.TestSuite(map(PCISkirootSoftboot, tests))
+    return unittest.TestSuite(list(map(PCISkirootSoftboot, tests)))
 
 def skiroot_hardboot_suite():
     '''
@@ -826,7 +828,7 @@ def skiroot_hardboot_suite():
     --run testcases.OpTestPCI.skiroot_hardboot_suite
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'compare_boot_devices']
-    return unittest.TestSuite(map(PCISkirootHardboot, tests))
+    return unittest.TestSuite(list(map(PCISkirootHardboot, tests)))
 
 def skiroot_suite():
     '''
@@ -837,7 +839,7 @@ def skiroot_suite():
     This suite does not care on soft vs hard boot
     '''
     tests = ['pcie_link_errors', 'compare_live_devices']
-    return unittest.TestSuite(map(PCISkiroot, tests))
+    return unittest.TestSuite(list(map(PCISkiroot, tests)))
 
 def skiroot_full_suite():
     '''
@@ -847,7 +849,7 @@ def skiroot_full_suite():
     This suite does not care on soft vs hard boot
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'driver_bind']
-    return unittest.TestSuite(map(PCISkiroot, tests))
+    return unittest.TestSuite(list(map(PCISkiroot, tests)))
 
 def host_softboot_suite():
     '''
@@ -856,7 +858,7 @@ def host_softboot_suite():
     --run testcases.OpTestPCI.host_softboot_suite
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'compare_boot_devices', 'driver_bind', 'hot_plug_host']
-    return unittest.TestSuite(map(PCIHostSoftboot, tests))
+    return unittest.TestSuite(list(map(PCIHostSoftboot, tests)))
 
 def host_hardboot_suite():
     '''
@@ -865,7 +867,7 @@ def host_hardboot_suite():
     --run testcases.OpTestPCI.host_hardboot_suite
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'compare_boot_devices', 'driver_bind', 'hot_plug_host']
-    return unittest.TestSuite(map(PCIHostHardboot, tests))
+    return unittest.TestSuite(list(map(PCIHostHardboot, tests)))
 
 def host_suite():
     '''
@@ -876,7 +878,7 @@ def host_suite():
     This suite does not care on soft vs hard boot
     '''
     tests = ['pcie_link_errors', 'compare_live_devices']
-    return unittest.TestSuite(map(PCIHost, tests))
+    return unittest.TestSuite(list(map(PCIHost, tests)))
 
 def host_full_suite():
     '''
@@ -886,4 +888,4 @@ def host_full_suite():
     This suite does not care on soft vs hard boot
     '''
     tests = ['pcie_link_errors', 'compare_live_devices', 'pci_link_check', 'driver_bind', 'hot_plug_host']
-    return unittest.TestSuite(map(PCIHost, tests))
+    return unittest.TestSuite(list(map(PCIHost, tests)))

--- a/testcases/OpalGard.py
+++ b/testcases/OpalGard.py
@@ -30,7 +30,12 @@ opal-gard
 
 Test different OPAL GARD Related functionality
 '''
+from __future__ import division
 
+from builtins import hex
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import re
 import random
 
@@ -88,7 +93,7 @@ class OpalGard(unittest.TestCase):
         self.c.run_command("dmesg -D")
         data = self.cv_HOST.host_pflash_get_partition("GUARD")
         try:
-          offset =  hex(int(data["offset"])/16)
+          offset =  hex(old_div(int(data["offset"]),16))
         except Exception as e:
           self.assertTrue(False, "OpenPOWER BMC unable to find valid offset for partition=GUARD")
         for i in range(0, 11):

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -28,6 +28,7 @@ We filter out any "known errors", such as how PRD can do invalid SCOMs but
 that it's not an error error.
 '''
 
+from builtins import object
 import unittest
 import re
 
@@ -37,7 +38,7 @@ from common.OpTestConstants import OpTestConstants as BMC_CONST
 from common.Exceptions import CommandFailed
 
 
-class OpalMsglog():
+class OpalMsglog(object):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.cv_HOST = conf.host()
@@ -103,7 +104,7 @@ class OpalMsglog():
                 fre = re.compile(f)
                 log_entries = [l for l in log_entries if not fre.search(l)]
 
-            msg = '\n'.join(filter(None, log_entries))
+            msg = '\n'.join([_f for _f in log_entries if _f])
             self.assertTrue(len(log_entries) == 0,
                             "Warnings/Errors in OPAL log:\n%s" % msg)
         except CommandFailed as cf:

--- a/testcases/PciSlotLocCodes.py
+++ b/testcases/PciSlotLocCodes.py
@@ -31,6 +31,7 @@ it is the system owner to make that determination.
 
 '''
 
+from builtins import range
 import unittest
 import re
 import os
@@ -67,7 +68,7 @@ class PciDT(unittest.TestCase):
             cls.cv_SYSTEM.goto_state(OpSystemState.PETITBOOT_SHELL)
 
     def dump_lspci(self, lspci_dict):
-        for key, value in lspci_dict.iteritems():
+        for key, value in lspci_dict.items():
             log.debug("Dumping lspci value={} key={} ".format(value, key))
 
     def build_lspci(self, lspci_dict={}):
@@ -98,7 +99,7 @@ class PciDT(unittest.TestCase):
         lspci_names = self.c.run_command("lspci -nn")
         lspci_names_dict = {}
         # 0006:00:00.0 Bridge [0680]: IBM Device [1014:04ea] (rev 01)
-        for key, value in lspci_dict.iteritems():
+        for key, value in lspci_dict.items():
             for i in range(len(lspci_names)):
                 if value in lspci_names[i]:
                     lspci_names_dict[key] = lspci_names[i]
@@ -219,7 +220,7 @@ class PciDT(unittest.TestCase):
                     .format(output_dict[key].get('loc-code')))
 
         if self.slot_failures != 0 or self.loccode_failures != 0:
-            failed_list = '\n'.join(filter(None, output_list))
+            failed_list = '\n'.join([_f for _f in output_list if _f])
             self.assertTrue(False, "PCI Root: Slot Label "
                 "or Loc Code Failures:\nBased on Platform "
                 "Slot Labels may not be present\n{}"

--- a/testcases/fspTODCorruption.py
+++ b/testcases/fspTODCorruption.py
@@ -29,10 +29,12 @@ FSP TOD Corruption
 Corrupt TOD and check host boot and runtime behaviours
 '''
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import time
-import subprocess
 import re
-import commands
+import subprocess
 
 from common.OpTestIPMI import OpTestIPMI
 from common.OpTestConstants import OpTestConstants as BMC_CONST
@@ -48,7 +50,7 @@ import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 
-class fspTODCorruption():
+class fspTODCorruption(object):
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.cv_IPMI = conf.ipmi()
@@ -68,7 +70,7 @@ class fspTODCorruption():
         return res
 
     def set_tod(self):
-        time = commands.getoutput('date +"%Y%m%d%H%M%S"')
+        time = subprocess.getoutput('date +"%Y%m%d%H%M%S"')
         log.debug("Setting back the system time using rtim timeofday ")
         cmd = "rtim timeofday %s" % time
         log.debug("Running command on FSP: %s" % cmd)


### PR DESCRIPTION
Add support for test scripts to run on both
Python2 and Python3
Not Tested.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>