### PR TITLE
OpTestUtil: bmc web logout timeout

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1846,7 +1846,8 @@ class Server(object):
         payload = {"data": []}
         try:
             # make direct call to requests post, by-pass loop_it
-            r = self.session.post(self._url(uri), json=payload)
+            # we only try for a short time (seconds) in case things are hung up
+            r = self.session.post(self._url(uri), json=payload, timeout=30)
             if r.status_code != requests.codes.ok:
                 log.debug("Requests post problem with logging "
                           "out, r.status_code={} r.text={} r.headers={} "


### PR DESCRIPTION
Set a short timeout for the logout on the bmc web server
in case things are hanging.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>