### PR TITLE
Add ssh support for SuSE prompt

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1171,9 +1171,9 @@ class OpTestUtil():
             if rc == 0:
                 pty.sendline(my_pwd)
                 time.sleep(0.5)
-                rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$",
+                rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~ #",
                                  'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
-                if rc not in [1, 2, 3]:
+                if rc not in [1, 2, 3, 4]:
                     if term_obj.setup_term_quiet == 0:
                         log.warning("OpTestSystem Problem with the login and/or password prompt,"
                                     " raised Exception ConsoleSettings but continuing")
@@ -1205,9 +1205,9 @@ class OpTestUtil():
                 if rc == 0:
                     pty.sendline(my_pwd)
                     time.sleep(0.5)
-                    rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$",
+                    rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~ #",
                                      'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
-                    if rc not in [1, 2, 3]:
+                    if rc not in [1, 2, 3, 4]:
                         if term_obj.setup_term_quiet == 0:
                             log.warning("OpTestSystem Problem with the login and/or password prompt,"
                                         " raised Exception ConsoleSettings but continuing")
@@ -1344,7 +1344,7 @@ class OpTestUtil():
         if system_obj.state == 3:  # OpSystemState.PETITBOOT
             return
 
-        rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~>",
+        rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~>", "~ #",
                          'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
         if rc == 0:
             track_obj.PS1_set, track_obj.LOGIN_set = self.get_login(
@@ -1352,7 +1352,7 @@ class OpTestUtil():
             track_obj.PS1_set, track_obj.SUDO_set = self.get_sudo(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
             return
-        if rc in [1, 2, 3, 4]:
+        if rc in [1, 2, 3, 4, 5]:
             track_obj.PS1_set = self.set_PS1(
                 term_obj, pty, self.build_prompt(system_obj.prompt))
             # ssh port 22 can get in which uses sshpass or Petitboot, do this after set_PS1 to make sure we have something
@@ -1360,9 +1360,9 @@ class OpTestUtil():
             track_obj.PS1_set, track_obj.SUDO_set = self.get_sudo(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
             return
-        if rc == 5:
+        if rc == 6:
             return  # Petitboot so nothing to do
-        if rc == 7:  # EOF
+        if rc == 8:  # EOF
             term_obj.close()  # mark as bad
             raise ConsoleSettings(before=pty.before, after=pty.after,
                                   msg="Getting login and sudo not successful, probably connection or credential issue, retry")
@@ -1375,20 +1375,20 @@ class OpTestUtil():
         # Ctrl-L may cause a esc[J (erase) character to appear in the buffer.
         # Include this in the patterns that expect $ (end of line)
         rc = pty.expect(['login: (\x1b\[J)*$', ".*#(\x1b\[J)*$", ".*# (\x1b\[J)*$", ".*\$(\x1b\[J)*",
-                         "~>(\x1b\[J)", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+                         "~>(\x1b\[J)", "~ #(\x1b\[J)", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
         if rc == 0:
             track_obj.PS1_set, track_obj.LOGIN_set = self.get_login(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
             track_obj.PS1_set, track_obj.SUDO_set = self.get_sudo(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
             return
-        if rc in [1, 2, 3, 4]:
+        if rc in [1, 2, 3, 4, 5]:
             track_obj.LOGIN_set = track_obj.PS1_set = self.set_PS1(
                 term_obj, pty, self.build_prompt(system_obj.prompt))
             track_obj.PS1_set, track_obj.SUDO_set = self.get_sudo(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))
             return
-        if rc == 5:
+        if rc == 6:
             return  # Petitboot do nothing
         else:
             if term_obj.setup_term_quiet == 0:


### PR DESCRIPTION
OpTestHost fails to get an ssh connection owing to expect tags which does not match SuSE prompt.
```
ConsoleSettings: Setting the prompt or logging in for the console was not successful, check credentials and review the following for more details
Expect Before Buffer="command-line line 0: Unsupported option "afstokenpassing"
Last login: Mon Apr 29 01:25:15 2019 from 9.124.35.213
linux-he6x:~ #
linux-he6x:~ # "
Expect After Buffer="<class 'pexpect.exceptions.EOF'>"
Message="Getting login and sudo not successful, probably connection issue, retry"
```
This patches fixes the above issue by adding a unique prompt
specific to handle SuSE prompt.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>