### PR TITLE
OpTestPCI: Ignore harmless timeout message.

### DIFF
--- a/testcases/OpTestPCI.py
+++ b/testcases/OpTestPCI.py
@@ -363,6 +363,10 @@ class OpClassPCI(unittest.TestCase):
                 total_entries = [l for l in total_entries if not fre.search(l)]
             log.debug("P9DSU FILTERED OUT total_entries={}".format(total_entries))
 
+        # Ignore debugging messages about empty slots
+        fre = re.compile('TRACE: Timeout waiting for link up')
+        total_entries = [l for l in total_entries if not fre.search(l)]
+
         msg = '\n'.join(filter(None, total_entries))
         log.debug("total_entries={}".format(total_entries))
         self.assertTrue( len(total_entries) == 0, "pcie link down/timeout Errors in OPAL log:\n{}".format(msg))


### PR DESCRIPTION
When a sufficient amount of debugging has been enabled[0] Skiboot will
produce messages of the form
	PHB#0030[8:0]: TRACE: Timeout waiting for link up
This is harmless and only represents an empty slot so filter it out on
all platforms.

Fixes #491

[0] nvram -p ibm,skiboot --update-config pci-tracing=true

Signed-off-by: Samuel Mendoza-Jonas <sam@mendozajonas.com>