### PR TITLE
Added dumprestart_lpar and restart_lpar

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -172,6 +172,22 @@ class OpTestHMC():
             self.wait_login_prompt(self.get_console_prompt())
             self.close_console(self.lpar_con)
 
+    def dumprestart_lpar(self):
+        if self.get_lpar_state() in [OpHmcState.NOT_ACTIVE, OpHmcState.NA]:
+            log.info('LPAR Already powered-off!')
+            return
+        self.run_command("chsysstate -m %s -r lpar -n %s -o dumprestart" %
+                         (self.system, self.lpar_name))
+        self.wait_lpar_state()
+
+    def restart_lpar(self):
+        if self.get_lpar_state() in [OpHmcState.NOT_ACTIVE, OpHmcState.NA]:
+            log.info('LPAR Already powered-off!')
+            return
+        self.run_command("chsysstate -m %s -r lpar -n %s -o shutdown --immed --restart" %
+                         (self.system, self.lpar_name))
+        self.wait_lpar_state()
+
     def get_lpar_state(self, vios=False):
         lpar_name = self.lpar_name
         if vios:


### PR DESCRIPTION
dumprestart_lpar and restart_lpar can be used for testing kdump and fadump on LPARs

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>

Logs
=======

linux-i4kf:~ # PS1=\[console-expect\]#
echo $?e-expect]#uname -a
uname -a
Linux linux-i4kf 4.12.14-100-default #1 SMP Fri Jun 7 13:05:05 UTC 2019 (ddfc532) ppc64le ppc64le ppc64le GNU/Linux
[console-expect]#echo $?
0
echo $?e-expect]#cat /etc/os-release | grep SLES
cat /etc/os-release | grep SLES
NAME="SLES"
[console-expect]#echo $?
0
[console-expect]#sed -i 's/crashkernel=[0-9]\+M/crashkernel=2G-4G:512M,4G-64G:1024M,64G-128G:2048M,128G-:409echo $?tc/default/grub;
24M,64G-128G:2048M,128G-:4096M/' /etc/default/grub;2M,4G-64G:10 
[console-expect]#echo $?
0
echo $?e-expect]#grub2-mkconfig -o /boot/grub2/grub.cfg
grub2-mkconfig -o /boot/grub2/grub.cfg
echo $?
Generating grub configuration file ...
Found linux image: /boot/vmlinux-4.12.14-100-default
Found initrd image: /boot/initrd-4.12.14-100-default
done
[console-expect]#echo $?
0
[console-expect]#[console-expect]#lssyscfg -m ltcfleet2 -r lpar --filter lpar_names=ltcfleet2-lp13-DistroFVT-S12SP4 -F state
lssyscfg -m ltcfleet2 -r lpar --filter lpar_names=ltcfleet2-lp13-DistroFVT-S12SP4 -F state
Running
[console-expect]#echo $?
echo $?
0
[console-expect]#chsysstate -m ltcfleet2 -r lpar -n ltcfleet2-lp13-DistroFVT-S12SP4 -o shutdown --immed --restart
chsysstate -m ltcfleet2 -r lpar -n ltcfleet2-lp13-DistroFVT-S12SP4 -o shutdown --immed --restart
[console-expect]#echo $?
echo $?
0
[console-expect]#lssyscfg -m ltcfleet2 -r lpar --filter lpar_names=ltcfleet2-lp13-DistroFVT-S12SP4 -F state
lssyscfg -m ltcfleet2 -r lpar --filter lpar_names=ltcfleet2-lp13-DistroFVT-S12SP4 -F state
Running
[console-expect]#echo $?
echo $?
0




IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM IBM 
