### PR TITLE
OpTestFlash: Convert byte object to string

### DIFF
--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -114,7 +114,7 @@ class OpTestFlashBase(unittest.TestCase):
             tar = tarfile.open(file_path)
             for member in tar.getmembers():
                 fd = tar.extractfile(member)
-                content = fd.read()
+                content = fd.read().decode("utf-8")
                 if "version=" in content:
                     content = content.split("\n")
                     content = [x for x in content if "version=" in x]


### PR DESCRIPTION
PNOR flashing is failing with below error.

======================================================================
FAIL: runTest (testcases.OpTestFlash.PNORFLASH)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opal/openpower/op-test/testcases/OpTestFlash.py", line 118, in get_version_tar
    if "version=" in content:
TypeError: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opal/openpower/op-test/testcases/OpTestFlash.py", line 378, in runTest
    version = self.get_version_tar(self.pnor)
  File "/opal/openpower/op-test/testcases/OpTestFlash.py", line 129, in get_version_tar
    "check if you have the proper file, Exception={}".format(e))
AssertionError: False is not true : Unexpected failure in get_version_tar, check if you have the proper file, Exception=a bytes-like object is required, not 'str'

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>