### PR TITLE
OpalGard: Fix python3 float type error

### DIFF
--- a/testcases/OpalGard.py
+++ b/testcases/OpalGard.py
@@ -41,6 +41,9 @@ import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 class OpalGard(unittest.TestCase):
     def setUp(self):
@@ -92,7 +95,7 @@ class OpalGard(unittest.TestCase):
         self.c.run_command("dmesg -D")
         data = self.cv_HOST.host_pflash_get_partition("GUARD")
         try:
-            offset = hex(int(data["offset"])/16)
+            offset = hex(data["offset"]//16)
         except Exception as e:
             self.assertTrue(
                 False, "OpenPOWER BMC unable to find valid offset for partition=GUARD")


### PR DESCRIPTION
Properly use floor/integer division.

Traceback (most recent call last):
  File "testcases/OpalGard.py", line 95, in runTest
    offset = hex(int(data["offset"])/16)
TypeError: 'float' object cannot be interpreted as an integer

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>