### PR TITLE
OPexpect: Python3 allow binary output

### DIFF
--- a/common/OPexpect.py
+++ b/common/OPexpect.py
@@ -43,7 +43,7 @@ class spawn(pexpect.spawn):
     def __init__(self, command, args=[], maxread=8000,
                  searchwindowsize=None, logfile=None, cwd=None, env=None,
                  ignore_sighup=False, echo=True, preexec_fn=None,
-                 encoding='utf-8', codec_errors='strict', dimensions=None,
+                 encoding='utf-8', codec_errors='ignore', dimensions=None,
                  failure_callback=None, failure_callback_data=None):
         self.command = command
         self.failure_callback = failure_callback
@@ -54,7 +54,8 @@ class spawn(pexpect.spawn):
                                     logfile=logfile,
                                     cwd=cwd, env=env,
                                     ignore_sighup=ignore_sighup,
-                                    encoding=encoding)
+                                    encoding=encoding,
+                                    codec_errors=codec_errors)
 
     def set_system(self, system):
         self.op_test_system = system


### PR DESCRIPTION
Allow pexpect to handle all binary data.

[console-expect]#PATH=/usr/local/sbin:$PATH pflash -r /dev/stdout -P VERSION
PATH=/usr/local/sbin:$PATH pflash -r /dev/stdout -P VERSION
Reading to "/dev/stdout" from 0x03228000..0x0322a000 !

Traceback (most recent call last):
  File "/home/debmc/test3/testcases/OpalUtils.py", line 218, in runTest
    self.flash_read_part()
  File "/home/debmc/test3/testcases/OpalUtils.py", line 162, in flash_read_part
    res = self.c.run_command(cmd, timeout=120)
  File "/home/debmc/test3/common/OpTestIPMI.py", line 340, in run_command
    return self.util.run_command(self, command, timeout, retry)
  File "/home/debmc/test3/common/OpTestUtil.py", line 1502, in run_command
    output = self.try_command(term_obj, command, timeout)
  File "/home/debmc/test3/common/OpTestUtil.py", line 1531, in try_command
    pexpect.TIMEOUT, pexpect.EOF], timeout=timeout)
  File "/home/debmc/test3/common/OPexpect.py", line 88, in expect
    searchwindowsize=searchwindowsize)
  File "/home/debmc/op-env/venv/lib/python3.7/site-packages/pexpect/spawnbase.py", line 341, in expect
    timeout, searchwindowsize, async_)
  File "/home/debmc/op-env/venv/lib/python3.7/site-packages/pexpect/spawnbase.py", line 369, in expect_list
    return exp.expect_loop(timeout)
  File "/home/debmc/op-env/venv/lib/python3.7/site-packages/pexpect/expect.py", line 111, in expect_loop
    incoming = spawn.read_nonblocking(spawn.maxread, timeout)
  File "/home/debmc/op-env/venv/lib/python3.7/site-packages/pexpect/pty_spawn.py", line 500, in read_nonblocking
    return super(spawn, self).read_nonblocking(size)
  File "/home/debmc/op-env/venv/lib/python3.7/site-packages/pexpect/spawnbase.py", line 178, in read_nonblocking
    s = self._decoder.decode(s, final=False)
  File "/home/debmc/op-env/venv/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 109: invalid start byte

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>