### PR TITLE
Fix OpTestInbandIPMI test_mc for debug skiboot

### DIFF
--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -385,7 +385,7 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase, unittest.TestCase):
                                    self.ipmi_method + BMC_CONST.IPMI_MC_SELFTEST])
         except CommandFailed as cf:
             # It's valid to not implement selftest, so let's not fail things on it.
-            if 'Selftest: not implemented' in cf.output[0]:
+            if 'Selftest: not implemented' in '\n'.join(cf.output):
                 pass
             else:
                 raise cf


### PR DESCRIPTION
We can get skiboot ipmi errors, so we should look at all lines of
output, not just the first - otherwise we get:

Command 'ipmitool mc selftest' exited with '1'. Output ['[
257.072567273,7] IPMI: Got error response. cmd=0x0, netfn=0x2d,
rc=0xc1', '[  257.076973965,7] IPMI: Got error response. cmd=0x0,
netfn=0x2d, rc=0xc1', 'Selftest: not implemented']

Signed-off-by: Stewart Smith <stewart@linux.ibm.com>