### PR TITLE
Fixup: Python3: Read vmlinux and initrd as binary

### DIFF
--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -507,13 +507,13 @@ class ThreadedHTTPHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             print(("# Webserver was asked for: ", self.path))
             if self.path == "/%s" % VMLINUX:
-                f = open("%s/%s" % (BASE_PATH, VMLINUX), "r")
+                f = open("%s/%s" % (BASE_PATH, VMLINUX), "rb")
                 d = f.read()
                 self.wfile.write(d)
                 f.close()
                 return
             elif self.path == "/%s" % INITRD:
-                f = open("%s/%s" % (BASE_PATH, INITRD), "r")
+                f = open("%s/%s" % (BASE_PATH, INITRD), "rb")
                 d = f.read()
                 self.wfile.write(d)
                 f.close()


### PR DESCRIPTION
Let's read vmlinux and initrd as binary to avoid
UnicodeDecodeError.
```
('# Webserver was asked for: ', '/vmlinuz')
----------------------------------------
Exception happened during processing of request from ('X.X.X.X', 49804)
Traceback (most recent call last):
  File "/usr/lib64/python3.6/socketserver.py", line 639, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib64/python3.6/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib64/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "/usr/lib64/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/usr/lib64/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "/home/jenkins/http_repo/sath/op-test-framework/common/OpTestInstallUtil.py", line 511, in do_GET
    d = f.read()
  File "/usr/lib64/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 31: invalid start byte
```
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>