### PR TITLE
Fixup python3: handle kickstart file read/write

### DIFF
--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -519,8 +519,8 @@ class ThreadedHTTPHandler(http.server.SimpleHTTPRequestHandler):
                 f.close()
                 return
             elif self.path == "/%s" % KS:
-                f = open("%s/%s" % (BASE_PATH, KS), "r")
-                d = f.read()
+                f = open("%s/%s" % (BASE_PATH, KS), "rb")
+                d = f.read().decode()
                 if "hostos" in BASE_PATH:
                     ps = d.format(REPO, PROXY, PASSWORD, DISK, DISK, DISK)
                 elif "rhel" in BASE_PATH:
@@ -545,7 +545,7 @@ class ThreadedHTTPHandler(http.server.SimpleHTTPRequestHandler):
                                   PROXY, PASSWORD, PASSWORD, user, PASSWORD, PASSWORD, DISK, packages)
                 else:
                     print("unknown distro")
-                self.wfile.write(ps)
+                self.wfile.write(ps.encode())
                 return
             else:
                 self.send_response(404)


### PR DESCRIPTION
Let's fix below errors by reading and writing with
proper decode/encode.
```
File "/home/bala/op-test-framework/common/OpTestInstallUtil.py", line 548, in do_GET
    self.wfile.write(ps)
File "/usr/lib64/python3.6/socketserver.py", line 803, in write
    self._sock.sendall(b)
TypeError: a bytes-like object is required, not 'str'
---
File "/home/bala/op-test-framework/common/OpTestInstallUtil.py", line 527, in do_GET
    ps = d.format(REPO, PROXY, PASSWORD, DISK, DISK, DISK).encode()
AttributeError: 'bytes' object has no attribute 'format'
```
Reported-by: Balamuruhan S <bala24@linux.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>