### PR TITLE
OpTestSystem: python3 encode sock.send

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1258,7 +1258,7 @@ class OpTestSystem(object):
                     log.debug("socket.error raise  Exception={}".format(e))
                     raise e
             try:
-                sock.send('Hello World!')
+                sock.send('Hello World!'.encode())
                 log.debug("sock send Hello World")
                 sock.close()
                 log.debug("sock close")


### PR DESCRIPTION
Need to encode the string for socket.

Signed-off-by: Deb McLemore <debmc@linux.ibm.com>