### PR TITLE
OpTestPrdDriver: Remove explicit passing of --pnor option

### DIFF
--- a/testcases/OpTestPrdDriver.py
+++ b/testcases/OpTestPrdDriver.py
@@ -255,7 +255,7 @@ class OpTestPrdDriver(unittest.TestCase):
             self.IPOLL_MASK_REGISTER_CONTENT = "a400000000000000"
 
         try:
-            l_con.run_command("opal-prd --pnor /dev/mtd0 --debug --stdio")
+            l_con.run_command("opal-prd --debug --stdio")
         except CommandFailed as cf:
             log.debug("opal-prd failed to activate %s" % str(cf))
 


### PR DESCRIPTION
`--pnor` option is not supported on FSP based system. And on
BMC based system `opal-prd` can detect right pnor.

Hence remove --pnor option.

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>