### PR TITLE
Modified InstallUpstreamKernel test to work for kexec boot

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -315,6 +315,8 @@ def get_parser():
         'git repo', 'Git repository details for upstream kernel install/boot')
     gitgroup.add_argument(
         "--git-repo", help="Kernel git repository", default=None)
+    gitgroup.add_argument(
+        "--git-repo-path", help="Linux source tar file path", default=None)
     gitgroup.add_argument("--git-repoconfigpath",
                           help="Kernel config file to be used", default=None)
     gitgroup.add_argument(


### PR DESCRIPTION
In case of 100s of builds on single system, cloning every time will
increase overall build time, so one more option --git-repo-path is
added to get the linux tar file

Also making sure the system is rebooted to base kernel before kernel
compilation, also if use_kexec option is given than do not install
kernel and do not update grub.cfg, as we do just kexec boot using
vmlinux and initramfs created for the new kernel

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>