### PR TITLE
FSP: avoid getting stuck in wait_for_standy()

### DIFF
--- a/common/OpTestFSP.py
+++ b/common/OpTestFSP.py
@@ -272,7 +272,16 @@ class OpTestFSP():
         throws exception on error.
         '''
         timeout = time.time() + 60*timeout
+        print("Waiting for the standby state")
         while True:
+            # This check shouldn't be necessary, but I've noticed that on
+            # some FSP systems op-test gets stuck in this wait loop it skipped
+            # the "standby" state and went straigh to "ipling" again. I have
+            # no idea why...
+            if self.is_sys_powered_on():
+                print("Hit runtime while waiting in wait_for_standby(), odd!");
+                self.sys_power_off()
+
             print(self.progress_line())
 
             if self.is_sys_standby():

--- a/testcases/OpTestFlash.py
+++ b/testcases/OpTestFlash.py
@@ -495,6 +495,7 @@ class OpalLidsFLASH(OpTestFlashBase):
         # test runs.
         self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
         self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        # FIXME: verify the system is actually off
         self.cv_SYSTEM.sys_sdr_clear()
         if "FSP" in self.bmc_type:
             self.cv_BMC.fsp_get_console()


### PR DESCRIPTION
I've noticed my CI jobs occasionally get stuck in wait_for_standby()
when powering the system off before flashing skiboot
(OpTestFlash.FlashOpalLids):

Running tests...
----------------------------------------------------------------------
  runTest (testcases.OpTestFlash.FSPFWImageFLASH) ... skip (0.016s)
  runTest (testcases.OpTestFlash.BmcImageFlash) ... skip (0.009s)
  runTest (testcases.OpTestFlash.PNORFLASH) ... skip (0.009s)
progress code [''], system state: runtime
progress code C100C1B0, system state: powering off
progress code C100C1B4, system state: powering off
progress code C1922000, system state: powering off
progress code C1922000, system state: powering off
progress code C1922000, system state: powering off
progress code C1922000, system state: powering off
progress code C1922000, system state: powering off
progress code [''], system state: ipling             <-- what?
progress code C1112000, system state: ipling
progress code C100C166, system state: ipling
progress code C11220FF, system state: ipling

The problem seems to be the FSP skips from "powering off" to "ipling"
and once it starts booting again the system will never go standby
unless we power it off again. Fix this by checking for the "runtime"
state. It'll take a bit longer, but it should work.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>