### PR TITLE
s/sys_power_off/power_off_sys/

### DIFF
--- a/common/OpTestFSP.py
+++ b/common/OpTestFSP.py
@@ -280,7 +280,7 @@ class OpTestFSP():
             # no idea why...
             if self.is_sys_powered_on():
                 print("Hit runtime while waiting in wait_for_standby(), odd!");
-                self.sys_power_off()
+                self.power_off_sys()
 
             print(self.progress_line())
 


### PR DESCRIPTION
sys_power_off() is a function of the OpTestSystem object rather than
not OpTestFSP so of course this doesn't work.

======================================================================
ERROR [0.201s]: runTest (testcases.OpTestFlash.OpalLidsFLASH)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/testcases/OpTestFlash.py", line 497, in runTest
    self.cv_SYSTEM.goto_state(OpSystemState.OFF)
  File "/mnt/common/OpTestSystem.py", line 389, in goto_state
    self.state = self.stateHandlers[self.state](state)
  File "/mnt/common/OpTestSystem.py", line 827, in run_POWERING_OFF
    BMC_CONST.SYSTEM_STANDBY_STATE_DELAY))
  File "/mnt/common/OpTestSystem.py", line 1357, in sys_wait_for_standby_state
    return self.cv_BMC.wait_for_standby(i_timeout)
  File "/mnt/common/OpTestFSP.py", line 283, in wait_for_standby
    self.sys_power_off()
AttributeError: 'OpTestFSP' object has no attribute 'sys_power_off'

Stupid intermittent bugs.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>