### PR TITLE
Fix hostlocker parsing off-by-one

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -799,7 +799,7 @@ class OpTestUtil():
                 break
 
         for key in list(args_dict.keys()):
-            for l in hostlocker_comment[offset:-1]:
+            for l in hostlocker_comment[offset:]:
                 line = l.strip()
                 if line.startswith(key + ":"):
                     value = re.sub(key + ':', "", line).strip()


### PR DESCRIPTION
When parsing the op-test configuration from a hostlocker machine blurb
we take a slice of all the lines following the '[op-test]' section
header and currently we drop the last line by accident.

The stop value in Python's slice notation isn't inclusive, so the slice
lines[offset:-1] won't include the last element in the list (at index -1).

I am really good at python.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>