### PR TITLE
Reworks

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -413,6 +413,12 @@ def get_parser():
     hmcgroup.add_argument(
         "--lpar-vios", help="Lpar VIOS to boot before other LPARS", default=None)
 
+    misc_group = parser.add_argument_group("Misc")
+    misc_group.add_argument("--check-ssh-keys", action='store_true', default=False,
+                            help="Check remote host keys when using SSH (auto-yes on new)")
+    misc_group.add_argument("--known-hosts-file",
+                            help="Specify a custom known_hosts file")
+
     return parser
 
 
@@ -479,11 +485,6 @@ class OpTestConfiguration():
 
         parser = get_parser()
         parser.set_defaults(**defaults)
-
-        parser.add_argument("--check-ssh-keys", action='store_true', default=False,
-                            help="Check remote host keys when using SSH (auto-yes on new)")
-        parser.add_argument("--known-hosts-file",
-                            help="Specify a custom known_hosts file")
 
         self.args, self.remaining_args = parser.parse_known_args(
             remaining_args)

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -480,14 +480,6 @@ class OpTestConfiguration():
         parser = get_parser()
         parser.set_defaults(**defaults)
 
-        if defaults.get('qemu_binary'):
-            qemu_default = defaults['qemu_binary']
-
-        if defaults.get('mambo_binary'):
-            mambo_default = defaults['mambo_binary']
-        if defaults.get('mambo_initial_run_script'):
-            mambo_default = defaults['mambo_initial_run_script']
-
         parser.add_argument("--check-ssh-keys", action='store_true', default=False,
                             help="Check remote host keys when using SSH (auto-yes on new)")
         parser.add_argument("--known-hosts-file",

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -418,6 +418,8 @@ def get_parser():
                             help="Check remote host keys when using SSH (auto-yes on new)")
     misc_group.add_argument("--known-hosts-file",
                             help="Specify a custom known_hosts file")
+    misc_group.add_argument("--accept-unknown-args", default=False, action='store_true',
+                            help="Don't exit if we find unknown command line arguments")
 
     return parser
 
@@ -486,8 +488,14 @@ class OpTestConfiguration():
         parser = get_parser()
         parser.set_defaults(**defaults)
 
-        self.args, self.remaining_args = parser.parse_known_args(
-            remaining_args)
+        # don't parse argv[0]
+        self.args, self.remaining_args = parser.parse_known_args(argv[1:])
+
+        # we use parse_known_args() and generate our own usage because the number
+        # of args makes the default usage string... unwieldy
+        if len(self.remaining_args) > 0 and not self.args.accept_unknown_args:
+            raise Exception("Unknown command line argument(s): {}"
+                                .format(str(self.remaining_args)))
 
         args_dict = vars(self.args)
 

--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -162,6 +162,8 @@ def get_parser():
                         help="List available suites to run")
     tgroup.add_argument("--list-tests", action='store_true',
                         help="List each test that would have been run")
+    tgroup.add_argument("--list-all-tests", action='store_true',
+                        help="List all defined tests")
     tgroup.add_argument("--run-suite", action='append',
                         help="Run a test suite(s)")
     tgroup.add_argument("--run", action='append',

--- a/op-test
+++ b/op-test
@@ -156,8 +156,19 @@ except Exception as e:
     print("Config error: {}".format(e));
     sys.exit(1)
 
-OpTestConfiguration.conf.objs()
+# create loggers, take hostlocks, etc
+try:
+    OpTestConfiguration.conf.do_testing_setup()
+except Exception as e:
+    print()
+    print("Test setup error! {}".format(e));
+    print()
+    print(traceback.format_exc())
+    print()
+    OpTestConfiguration.conf.util.cleanup()
+    sys.exit(1)
 
+OpTestConfiguration.conf.objs()
 
 class SystemAccessSuite():
     '''

--- a/op-test
+++ b/op-test
@@ -112,7 +112,6 @@ import re
 import signal
 import logging
 import OpTestLogger
-import importlib
 # op-test is the parent logger
 optestlog = logging.getLogger(OpTestLogger.optest_logger_glob.parent_logger)
 
@@ -836,8 +835,6 @@ try:
             print('{0:34}{1}'.format(key, suites[key].__doc__))
         OpTestConfiguration.conf.util.cleanup()
         exit(0)
-
-    importlib.reload(sys)
 
     t = unittest.TestSuite()
 

--- a/op-test
+++ b/op-test
@@ -156,6 +156,18 @@ except Exception as e:
     print("Config error: {}".format(e));
     sys.exit(1)
 
+def print_tests(s):
+    for test in s:
+        if isinstance(test, unittest.TestSuite):
+            print_tests(test)
+        else:
+            test_id = test.id()
+            print('{0:40}'.format(test_id))
+
+if OpTestConfiguration.conf.args.list_all_tests:
+    print_tests(unittest.TestLoader().discover('testcases', '*.py'))
+    exit(0)
+
 # create loggers, take hostlocks, etc
 try:
     OpTestConfiguration.conf.do_testing_setup()
@@ -875,18 +887,9 @@ try:
             t.addTest(suites['default'].suite())
 
     if OpTestConfiguration.conf.args.list_tests:
-        print('{0:40}'.format('Test'))
+        print('{0:40}'.format('Tests'))
         print('{0:40}'.format('----------'))
-
-        def print_suite(s):
-            for test in s:
-                if isinstance(test, unittest.TestSuite):
-                    print_suite(test)
-                else:
-                    test_id = test.id()
-                    print('{0:40}'.format(test_id))
-
-        print_suite(t)
+        print_tests(t)
         OpTestConfiguration.conf.util.cleanup()
         exit(0)
 

--- a/op-test
+++ b/op-test
@@ -148,7 +148,14 @@ signal.signal(signal.SIGSEGV, optest_handler)
 signal.signal(signal.SIGTERM, optest_handler)
 signal.signal(signal.SIGUSR1, optest_handler)
 signal.signal(signal.SIGUSR2, optest_handler)
-args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
+
+# parse config options and create log files, take the host lock, etc.
+try:
+    args, remaining_args = OpTestConfiguration.conf.parse_args(sys.argv)
+except Exception as e:
+    print("Config error: {}".format(e));
+    sys.exit(1)
+
 OpTestConfiguration.conf.objs()
 
 

--- a/testcases/OpTestInbandUsbInterface.py
+++ b/testcases/OpTestInbandUsbInterface.py
@@ -51,8 +51,7 @@ import unittest
 
 import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
-from testcases.OpTestInbandIPMI import BasicInbandIPMI, OpTestInbandIPMI, ExperimentalInbandIPMI
-from testcases.OpTestInbandIPMI import SkirootBasicInbandIPMI, SkirootFullInbandIPMI
+import testcases.OpTestInbandIPMI as ib
 
 
 def experimental_suite():
@@ -71,7 +70,7 @@ def skiroot_full_suite():
     return unittest.defaultTestLoader.loadTestsFromTestCase(SkirootInbandUSB)
 
 
-class BasicInbandUSB(BasicInbandIPMI):
+class BasicInbandUSB(ib.BasicInbandIPMI):
     def setUp(self, ipmi_method=BMC_CONST.IPMITOOL_USB):
         self.bmc_type = OpTestConfiguration.conf.args.bmc_type
         if "FSP" in self.bmc_type:
@@ -81,7 +80,7 @@ class BasicInbandUSB(BasicInbandIPMI):
         super(BasicInbandUSB, self).setUp(ipmi_method=ipmi_method)
 
 
-class InbandUSB(OpTestInbandIPMI):
+class InbandUSB(ib.OpTestInbandIPMI):
     def setUp(self, ipmi_method=BMC_CONST.IPMITOOL_USB):
         self.bmc_type = OpTestConfiguration.conf.args.bmc_type
         if "FSP" in self.bmc_type:
@@ -91,7 +90,7 @@ class InbandUSB(OpTestInbandIPMI):
         super(InbandUSB, self).setUp(ipmi_method=ipmi_method)
 
 
-class SkirootBasicInbandUSB(SkirootBasicInbandIPMI):
+class SkirootBasicInbandUSB(ib.SkirootBasicInbandIPMI):
     def setUp(self, ipmi_method=BMC_CONST.IPMITOOL_USB):
         self.bmc_type = OpTestConfiguration.conf.args.bmc_type
         if "FSP" in self.bmc_type:
@@ -101,7 +100,7 @@ class SkirootBasicInbandUSB(SkirootBasicInbandIPMI):
         super(SkirootBasicInbandUSB, self).setUp(ipmi_method=ipmi_method)
 
 
-class SkirootInbandUSB(SkirootFullInbandIPMI):
+class SkirootInbandUSB(ib.SkirootFullInbandIPMI):
     def setUp(self, ipmi_method=BMC_CONST.IPMITOOL_USB):
         self.bmc_type = OpTestConfiguration.conf.args.bmc_type
         if "FSP" in self.bmc_type:
@@ -111,7 +110,7 @@ class SkirootInbandUSB(SkirootFullInbandIPMI):
         super(SkirootInbandUSB, self).setUp(ipmi_method=ipmi_method)
 
 
-class ExperimentalInbandUSB(ExperimentalInbandIPMI):
+class ExperimentalInbandUSB(ib.ExperimentalInbandIPMI):
     def setUp(self, ipmi_method=BMC_CONST.IPMITOOL_USB):
         self.bmc_type = OpTestConfiguration.conf.args.bmc_type
         if "FSP" in self.bmc_type:


### PR DESCRIPTION
Does a few random things:

1. Removes some random hacks
2. Rework the config file parsing to report parse errors rather than silently ignoring them
3. makes op-test reject any command line arguments that it doesn't recognise
4. Add a --list-all-tests which uses the unittest module's builtin test loader to find all the defined tests in testscases/ 