### PR TITLE
Remove timestamp prefixes from logfile

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -561,7 +561,7 @@ class OpTestConfiguration():
         self.outsuffix = self.get_suffix()
 
         # set up where all the logs go
-        logfile = os.path.join(self.output, "%s.log" % self.outsuffix)
+        logfile = os.path.join(self.output, "host-console.log")
 
         logcmd = "tee %s" % (logfile)
         # we use 'cat -v' to convert control characters
@@ -577,10 +577,9 @@ class OpTestConfiguration():
             OpTestLogger.optest_logger_glob.sh_level = logging.INFO
             OpTestLogger.optest_logger_glob.sh.setLevel(logging.INFO)
 
-        OpTestLogger.optest_logger_glob.setUpLoggerFile(
-            datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.main.log')
-        OpTestLogger.optest_logger_glob.setUpLoggerDebugFile(
-            datetime.utcnow().strftime("%Y%m%d%H%M%S%f")+'.debug.log')
+        OpTestLogger.optest_logger_glob.setUpLoggerFile('main.log')
+        OpTestLogger.optest_logger_glob.setUpLoggerDebugFile('debug.log')
+
         OpTestLogger.optest_logger_glob.optest_logger.info(
             'TestCase Log files: {}/*'.format(self.output))
         OpTestLogger.optest_logger_glob.optest_logger.info(


### PR DESCRIPTION
We already put them in a timestamped directory. There's not much point
in repeating it on the individual log files and as the logs are rotated
the timestamps drift which makes then annoying to tab complete.

If someone really wants to keep the timestamps then we could change the
prefix to a suffix I guess.

Old:
    $ ls -1 test-reports/latest/*
    test-reports/latest/20191212080156693511.main.log
    test-reports/latest/20191212080156693830.debug.log
    test-reports/latest/20191212190156.log
    test-reports/latest/op-test-esel.Thu_Dec_12_19:02:51_2019

New:
    $ ls -1 test-reports/latest/*
    test-reports/latest/debug.log
    test-reports/latest/host-console.log
    test-reports/latest/main.log
    test-reports/latest/op-test-esel.Thu_Dec_12_18:43:12_2019

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>