### PR TITLE
Check if the Host is powered off before probing the console

### DIFF
--- a/common/OpTestConstants.py
+++ b/common/OpTestConstants.py
@@ -157,8 +157,6 @@ class OpTestConstants():
     ERROR_SELENIUM_HEADLESS = "Host doesn't have selenium installed"
     POWER_ACTIVATE_SUCCESS = "Power limit successfully activated"
     POWER_DEACTIVATE_SUCCESS = "Power limit successfully deactivated"
-    CHASSIS_POWER_ON = 'Chassis Power is on'
-    CHASSIS_POWER_OFF = 'Chassis Power is off'
     GARD_CLEAR_SUCCESSFUL = 'Clearing the entire gard partition...done'
     NO_GARD_RECORDS = 'No GARD entries to display'
     CMD_NOT_FOUND = 'command not found'

--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -675,14 +675,13 @@ class OpTestIPMI():
         '''
         Determines the power status of the bmc
 
-        :returns: string: Power status of bmc
-                          "Chassis Power is on" or "Chassis Power is off"
+        :returns: Bool: True if the system is powered on.
         '''
         l_output = self.ipmitool.run('chassis power status')
         if('on' in l_output):
-            return BMC_CONST.CHASSIS_POWER_ON
+            return True
         elif('off' in l_output):
-            return BMC_CONST.CHASSIS_POWER_OFF
+            return False
         else:
             raise OpTestError(
                 "Can't recognize chassis power status: " + str(l_output))

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -408,6 +408,10 @@ class OpTestSystem(object):
                 self.util.check_nvram_options(self.console)
 
     def run_DETECT(self, target_state):
+        if not self.sys_power_is_on():
+            log.info("Detected powered off system")
+            return OpSystemState.OFF
+
         self.detect_counter += 1
         detect_state = OpSystemState.UNKNOWN
         if self.detect_counter >= 3:
@@ -915,6 +919,9 @@ class OpTestSystem(object):
         except OpTestError as e:
             return BMC_CONST.FW_FAILED
         return rc
+
+    def sys_power_is_on(self):
+        return self.cv_IPMI.ipmi_power_status()
 
     ##
     # @brief Power off the system


### PR DESCRIPTION
Before we spend time trying to detect what system the state is in by
writing to the host console we should check if the host is powered on
or not.

I don't think I've seen a BMC give a false-off so this should be
reliable and save a bit of time on the probing. This isn't critical for
CI runs, but it's nice when using op-test manually from the command
line.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>