### PR TITLE
OpTestOpenBMC.py: increase wait_bmc() timeout

### DIFF
--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -480,7 +480,7 @@ class HostManagement():
                 message="HTTP problem getting CurrentBMCState {}".format(problem))
         return r.json().get('data')
 
-    def wait_bmc(self, key=None, value_target=None, token=None, minutes=10):
+    def wait_bmc(self, key=None, value_target=None, token=None, minutes=15):
         '''
         Wait on BMC
         Given a token, target, key wait for a match


### PR DESCRIPTION
Swift systems are taking more than 10 minutes between poweroff/poweron.
Increase the timeout to 15 minutes.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>