### PR TITLE
Revert "OpTestOpenBMC.py: increase wait_bmc() timeout"

### DIFF
--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -480,7 +480,7 @@ class HostManagement():
                 message="HTTP problem getting CurrentBMCState {}".format(problem))
         return r.json().get('data')
 
-    def wait_bmc(self, key=None, value_target=None, token=None, minutes=15):
+    def wait_bmc(self, key=None, value_target=None, token=None, minutes=10):
         '''
         Wait on BMC
         Given a token, target, key wait for a match


### PR DESCRIPTION
Reverts open-power/op-test#588

Apologies for the noise. I'm convinced that the root-cause for recent failures in the CI systems is not related to the timeout, so I'm reverting this.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>