### PR TITLE
Adjust OpenBMC PowerOff and global SniffTest

### DIFF
--- a/common/OpTestOpenBMC.py
+++ b/common/OpTestOpenBMC.py
@@ -144,18 +144,9 @@ class HostManagement():
         PUT
         https://bmcip/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition
         "data": "xyz.openbmc_project.State.Chassis.Transition.Off"
-
-        PUT
-        https://bmcip/xyz/openbmc_project/state/host0/attr/RequestedHostTransition
-        "data": "xyz.openbmc_project.State.Chassis.Transition.Off"
         '''
         uri = "/xyz/openbmc_project/state/chassis0/attr/RequestedPowerTransition"
         payload = {"data": "xyz.openbmc_project.State.Chassis.Transition.Off"}
-        r = self.conf.util_bmc_server.put(
-            uri=uri, json=payload, minutes=minutes)
-
-        uri = "/xyz/openbmc_project/state/host0/attr/RequestedHostTransition"
-        payload = {"data": "xyz.openbmc_project.State.Host.Transition.Off"}
         r = self.conf.util_bmc_server.put(
             uri=uri, json=payload, minutes=minutes)
 

--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1523,7 +1523,9 @@ class OpTestOpenBMCSystem(OpTestSystem):
         self.rest.list_sel()
 
     def sys_wait_for_standby_state(self, i_timeout=120):
-        self.rest.wait_for_standby()
+        # wait_for_standby() takes timeout in minutes.
+        # In Python3 this will be always a float, but looks like we're alright
+        self.rest.wait_for_standby(timeout=i_timeout/60)
         return 0
 
     def wait_for_it(self, **kwargs):

--- a/testcases/OpTestHostboot.py
+++ b/testcases/OpTestHostboot.py
@@ -70,7 +70,10 @@ class OpTestHostboot(unittest.TestCase):
         log.debug("System Power Off")
         self.cv_SYSTEM.sys_power_off()
         self.cv_SYSTEM.set_state(OpSystemState.UNKNOWN_BAD)
-        time.sleep(30)
+        log.debug("Wait for Standby")
+        # Use 300 seconds as timeout as some systems will take longer
+        # to runtime even with immediate power_off
+        self.cv_SYSTEM.sys_wait_for_standby_state(i_timeout=300)
         log.debug("System Power On")
         self.cv_SYSTEM.sys_power_on()
         count = self.threshold_attempts


### PR DESCRIPTION
In early OpenBMC targets, we were told to issue both immediate (chassis)
as well as soft (host) poweroff in our sys_power_off() path. This is no
longer the recommendation, so adjust to be consistent with IPMI and LPAR
methods that issue an immediate power off.

Additionally, we're also been told that 30 seconds might not be enough
even for an immediate PowerOff in some (upcoming?) systems, so adjust
the SniffTest logic so we wait_for_standby() before issuing a PowerOn.

This should fix some CI scenarios where the BMC was executing a soft
power off (even if we're issuing both immediate and soft) and the 30
second delay was not sufficient before we could issue a poweron -
intermintently failing the test.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>