### PR TITLE
Allow Unspecificed Error in SkirootFullInbandIPMI.test_chassis

### DIFF
--- a/testcases/OpTestInbandIPMI.py
+++ b/testcases/OpTestInbandIPMI.py
@@ -153,8 +153,10 @@ class OpTestInbandIPMI(OpTestInbandIPMIBase, unittest.TestCase):
             self.run_ipmi_cmds(
                 c, [self.ipmi_method + BMC_CONST.IPMI_CHASSIS_RESTART_CAUSE])
         except CommandFailed as cf:
-            if 'Get Chassis Restart Cause failed: Invalid command' in cf.output[0]:
+            if 'Get Chassis Restart Cause failed: Invalid command' in cf.output:
                 self.skipTest("OpenBMC doesn't implement restart_cause yet")
+            if 'Get Chassis Restart Cause failed: Unspecified error' in cf.output:
+                self.skipTest("OpenBMC does implement restart_cause, but D-BUS backend doesn't")
             self.fail(str(cf))
 
         self.run_ipmi_cmds(c, [self.ipmi_method + BMC_CONST.IPMI_CHASSIS_POLICY_LIST,


### PR DESCRIPTION
Recent OpenBMC versions are now implementing the 'restart_cause' IPMI
command, but unsurprisingly the d-bus interface is not yet implemented,
so add this quirk to skip the test when getting an "Unspecified Error"

Additionally, allow this output to be in any of the command output's
list, because some IPMI daemon console errors might leak into this
command's output as well.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>