### PR TITLE
testcases.Console.Control[C|Z]: Increase timeout

### DIFF
--- a/testcases/Console.py
+++ b/testcases/Console.py
@@ -176,7 +176,8 @@ class ControlC(unittest.TestCase):
             # the timeout needs to be long enough so the pty spawn object has time
             # to figure out the sockets are dead, we've seen like 40-50 secs
             log.debug("Control-C/Z back from sendcontrol {}".format(self.CONTROL))
-            rc = raw_pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=90)
+            # We're using an oversized timeout due to LTC Bug 186797 (OpenBMC)
+            rc = raw_pty.expect([self.prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=180)
             log.debug("Control-C/Z rc={}".format(rc))
             log.debug("Control-C/Z before={}".format(raw_pty.before))
             log.debug("Control-C/Z after={}".format(raw_pty.after))


### PR DESCRIPTION
Due to an OpenBMC Bug we're intermittently hitting a timeout on
ControlC/ControlZ Console tests. Work around this by doubling the
timeout. On my tests, each iteration takes between 60-140 seconds, so
the 5 iterations are taking a good 10 minutes to complete, also
generating *a lot* of debug logs.

But before the OpenBMC bug is fixes, it's better than failing and
re-trying the test.

Once this is fixed, we should put this back to a sane default (say 10
seconds?)

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>