### PR TITLE
Fixup and few enhancements for kernel command line test

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -332,6 +332,8 @@ def get_parser():
         "--use-kexec", help="Use kexec to boot to new kernel", action='store_true', default=False)
     gitgroup.add_argument("--append-kernel-cmdline",
                           help="Append kernel commandline while booting with kexec", default=None)
+    gitgroup.add_argument(
+        "--use-reboot", help="Use reboot command replacing a hard power off/on", action='store_true', default=False)
 
     imagegroup = parser.add_argument_group(
         'Images', 'Firmware LIDs/images to flash')

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -405,7 +405,8 @@ class InstallUtil():
                    (Err.command, Err.output)))
         return req_args.strip(), req_remove_args.strip()
 
-    def update_kernel_cmdline(self, distro, args="", remove_args="", reboot=True):
+    def update_kernel_cmdline(self, distro, args="", remove_args="", reboot=True,
+                              reboot_cmd=False):
         """
         Update default Kernel cmdline arguments
 
@@ -464,8 +465,13 @@ class InstallUtil():
                     return False
         if reboot and (req_args or req_remove_args):
             # Reboot the host for the kernel command to reflect
-            self.cv_SYSTEM.goto_state(OpSystemState.OFF)
-            self.cv_SYSTEM.goto_state(OpSystemState.OS)
+            if reboot_cmd:
+                raw_pty = self.cv_SYSTEM.console.get_console()
+                raw_pty.sendline("reboot")
+                raw_pty.expect("login:", timeout=900)
+            else:
+                self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+                self.cv_SYSTEM.goto_state(OpSystemState.OS)
 
             # check for added/removed args in /proc/cmdline
             req_args, req_remove_args = self.check_kernel_cmdline(args,

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -405,7 +405,7 @@ class InstallUtil():
                    (Err.command, Err.output)))
         return req_args.strip(), req_remove_args.strip()
 
-    def update_kernel_cmdline(self, args="", remove_args="", reboot=True):
+    def update_kernel_cmdline(self, distro, args="", remove_args="", reboot=True):
         """
         Update default Kernel cmdline arguments
 
@@ -454,7 +454,10 @@ class InstallUtil():
                     cmd = "sed -i 's/%s=.*/%s=\"%s\"/g' %s" % (grub_key, grub_key,
                                                                output, boot_cfg)
                     con.run_command(cmd, timeout=60)
-                    con.run_command("update-grub")
+                    if 'Ubuntu' in distro:
+                        con.run_command('update-grub')
+                    else:
+                        con.run_command('grub2-mkconfig -o /boot/grub2/grub.cfg')
                 except CommandFailed as Err:
                     print(("Failed to update kernel commandline - %s: %s" %
                            (Err.command, Err.output)))

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -415,6 +415,7 @@ class InstallUtil():
 
         :return: True on success and False on failure
         """
+        output = ""
         con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         req_args, req_remove_args = self.check_kernel_cmdline(args,
                                                               remove_args)
@@ -435,15 +436,15 @@ class InstallUtil():
         except CommandFailed:
             grub_key = "GRUB_CMDLINE_LINUX_DEFAULT"
             boot_cfg = self.get_boot_cfg()
-            cmd = ("cat %s | grep %s | awk -F '=' '{print $2}'" %
-                   (boot_cfg, grub_key))
+            cmd = "grep %s %s" % (grub_key, boot_cfg)
             try:
-                output = con.run_command(cmd, timeout=60)[0].strip("\"")
+                output = con.run_command(cmd, timeout=60)[0].replace("\"", "")
+                output = output.split("GRUB_CMDLINE_LINUX_DEFAULT=")[-1].strip()
                 if req_args:
                     output += " %s" % req_args
                 if req_remove_args:
                     for each_arg in req_remove_args.split():
-                        output = output.strip(each_arg).strip()
+                        output = output.replace(each_arg, "")
             except CommandFailed as Err:
                 print(("Failed to get the kernel commandline - %s: %s" %
                        (Err.command, Err.output)))

--- a/testcases/OpTestKernelArg.py
+++ b/testcases/OpTestKernelArg.py
@@ -40,6 +40,7 @@ class OpTestKernelArg(unittest.TestCase):
 
     def setUp(self):
         self.conf = OpTestConfiguration.conf
+        self.cv_HOST = self.conf.host()
         self.kernel_add_args = self.conf.args.add_kernel_args
         self.kernel_remove_args = self.conf.args.remove_kernel_args
         if not (self.kernel_add_args or self.kernel_remove_args):
@@ -48,6 +49,7 @@ class OpTestKernelArg(unittest.TestCase):
 
     def runTest(self):
         obj = OpTestInstallUtil.InstallUtil()
-        if not obj.update_kernel_cmdline(self.kernel_add_args,
+        if not obj.update_kernel_cmdline(self.cv_HOST.host_get_OS_Level(),
+                                         self.kernel_add_args,
                                          self.kernel_remove_args):
             self.fail("KernelArgTest failed to update kernel args")

--- a/testcases/OpTestKernelArg.py
+++ b/testcases/OpTestKernelArg.py
@@ -43,6 +43,7 @@ class OpTestKernelArg(unittest.TestCase):
         self.cv_HOST = self.conf.host()
         self.kernel_add_args = self.conf.args.add_kernel_args
         self.kernel_remove_args = self.conf.args.remove_kernel_args
+        self.use_reboot_cmd = self.conf.args.use_reboot
         if not (self.kernel_add_args or self.kernel_remove_args):
             self.fail("Provide either --add-kernel-args and "
                       "--remove-kernel-args option")
@@ -51,5 +52,7 @@ class OpTestKernelArg(unittest.TestCase):
         obj = OpTestInstallUtil.InstallUtil()
         if not obj.update_kernel_cmdline(self.cv_HOST.host_get_OS_Level(),
                                          self.kernel_add_args,
-                                         self.kernel_remove_args):
+                                         self.kernel_remove_args,
+                                         reboot=True,
+                                         reboot_cmd=self.use_reboot_cmd):
             self.fail("KernelArgTest failed to update kernel args")


### PR DESCRIPTION
1. Fix: Extract commandline arguments properly
awk fails to get the proper kernel commandline params as few of the contain "=" character. Hence using a more easier way to get the entire string.
Using str.replace instead of strip which only string leading or trailing matches.
Also define output variable before use

2. Add distro parameter to update grub
Patch adds distro level so that grub configuration can be updated according to the same

3. Add --use-reboot command line option for OpTestKernelArg test
Patch adds --use-reboot command line option to explicitly use reboot command once kernel command line is updated

Signed-off-by: Harish <harish@linux.ibm.com>