### PR TITLE
OpTestFastReboot: Add 'force-fast-reset' to nvram

### DIFF
--- a/testcases/OpTestFastReboot.py
+++ b/testcases/OpTestFastReboot.py
@@ -131,6 +131,9 @@ class OpTestFastReboot(unittest.TestCase):
             self.skipTest("OpTestSystem does not have MTD PNOR access,"
                           "so skipping Fast Reboot")
 
+        # Throughout skiboot history, there were several different ways of
+        # forcing fast-reset, to change the changing defaults as well.
+        # Use all of them since we need to support different skiboot levels
         c.run_command("nvram -p ibm,skiboot --update-config fast-reset=1")
         res = c.run_command("nvram --print-config=fast-reset -p ibm,skiboot")
         self.assertNotIn("0", res, "Failed to set the fast-reset mode")
@@ -138,6 +141,9 @@ class OpTestFastReboot(unittest.TestCase):
         res = c.run_command(BMC_CONST.NVRAM_PRINT_FAST_RESET_VALUE)
         self.assertIn("feeling-lucky", res,
                       "Failed to set the fast-reset mode")
+        c.run_command("nvram -p ibm,skiboot --update-config force-fast-reset=1")
+        res = c.run_command("nvram --print-config=force-fast-reset -p ibm,skiboot")
+        self.assertIn("1", res, "Failed to set force-fast-reset")
         initialResetCount = self.get_fast_reset_count(c)
         log.debug("INITIAL reset count: %d" % initialResetCount)
         for i in range(0, self.number_reboots_to_do()):


### PR DESCRIPTION
Skiboot 6.6 release notes has the following to say:

---
- Fast-reboot is now disabled by default.

  Fast-reboot will continue to be supported, but as an opt-in feature rather
  than the default. From the commit (ee07f2c68160) message::

    This has two user visible changes:

    1. Full reboot is now the default. In order to get fast-reboot as the
       default the nvram option needs to be set:

            nvram -p ibm,skiboot --update-config fast-reset=1

    2. The nvram option to force a fast-reboot even when some part of
       skiboot has called disable_fast_reboot() has changed from
       'fast-reset=im-feeling-lucky' to 'force-fast-reset=1' because
       it's impossible to actually use that 'feature' if fast-reboot is
       off by default.

            nvram -p ibm,skiboot --update-config force-fast-reset=1
---

Since we're expecting this testcase to force fast-reboot, adjust
accordingly..

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>