### PR TITLE
SkirootSuite: Temporarily Disable FastReboot

### DIFF
--- a/op-test
+++ b/op-test
@@ -231,7 +231,8 @@ class SkirootSuite():
         self.s.addTest(OpTestPCI.skiroot_suite())
         self.s.addTest(PetitbootDropbearServer.PetitbootDropbearServer())
         self.s.addTest(Petitbooti18n.Petitbooti18n())
-        self.s.addTest(OpTestFastReboot.OpTestFastReboot())
+        # disabling temporarily
+#        self.s.addTest(OpTestFastReboot.OpTestFastReboot())
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())
         self.s.addTest(Console.suite())


### PR DESCRIPTION
Something in between skiboot-v6.6-85-gabe4c4799 and
skiboot-v6.6-111-gd362ae4f4 broke fast-reset.

Disabling temporarily while we figure it out.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>