### PR TITLE
Revert "SkirootSuite: Temporarily Disable FastReboot"

### DIFF
--- a/op-test
+++ b/op-test
@@ -231,8 +231,7 @@ class SkirootSuite():
         self.s.addTest(OpTestPCI.skiroot_suite())
         self.s.addTest(PetitbootDropbearServer.PetitbootDropbearServer())
         self.s.addTest(Petitbooti18n.Petitbooti18n())
-        # disabling temporarily
-#        self.s.addTest(OpTestFastReboot.OpTestFastReboot())
+        self.s.addTest(OpTestFastReboot.OpTestFastReboot())
         self.s.addTest(OpTestHeartbeat.HeartbeatSkiroot())
         self.s.addTest(OpTestNVRAM.SkirootNVRAM())
         self.s.addTest(Console.suite())


### PR DESCRIPTION
Reverts open-power/op-test#605

https://github.com/open-power/skiboot/issues/259#issuecomment-735674424 got fixed.

Signed-off-by: Klaus Heinrich Kiwi <klaus@linux.vnet.ibm.com>