### PR TITLE
OpTestFSP: pass in custom fps prompt to constructor

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -789,6 +789,7 @@ class OpTestConfiguration():
                                 self.args.bmc_username,
                                 self.args.bmc_password,
                                 ipmi=ipmi,
+                                prompt=self.args.fsp_prompt if hasattr(self.args, 'fsp_prompt') else "$",
                                 )
                 self.op_system = common.OpTestSystem.OpTestFSPSystem(
                     state=self.startState,
@@ -830,6 +831,7 @@ class OpTestConfiguration():
                                 self.args.bmc_username,
                                 self.args.bmc_password,
                                 hmc=hmc,
+                                prompt=self.args.fsp_prompt if hasattr(self.args, 'fsp_prompt') else "$",
                                 )
                 self.op_system = common.OpTestSystem.OpTestLPARSystem(
                     state=self.startState,

--- a/common/OpTestFSP.py
+++ b/common/OpTestFSP.py
@@ -58,11 +58,11 @@ class OpTestFSP():
     Contains most of the common methods to interface with FSP.
     '''
 
-    def __init__(self, i_fspIP, i_fspUser, i_fspPasswd, ipmi=None, hmc=None, rest=None):
+    def __init__(self, i_fspIP, i_fspUser, i_fspPasswd, ipmi=None, hmc=None, rest=None, prompt="$"):
         self.host_name = i_fspIP
         self.user_name = i_fspUser
         self.password = i_fspPasswd
-        self.prompt = "$"
+        self.prompt = prompt
         self.cv_ASM = OpTestASM(i_fspIP, i_fspUser, i_fspPasswd)
         self.cv_IPMI = ipmi
         self.cv_HMC = hmc


### PR DESCRIPTION
Currently, when logging into FSP op-test expects the machine to have the prompt
"$". When a machine has a different prompt (my machine has "fspbash-4.2#"), the
test gets stuck expecting "$" and doesn't move on.

This patch adds the ability to send in a custom FSP prompt as an argument.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>