### PR TITLE
Prerequisites check for LPM test.

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -250,7 +250,7 @@ class HMCUtil():
         lpar_list = self.ssh.run_command(
                    'lssyscfg -r lpar -m %s -F name' % mg_system)
         if self.lpar_name in lpar_list:
-            log.info("%s lpar found in managed system %s" % (mg_system, self.lpar_name))
+            log.info("%s lpar found in managed system %s" % (self.lpar_name, mg_system))
             return True
         return False
 
@@ -262,7 +262,7 @@ class HMCUtil():
         self.ssh.run_command(
             'migrlpar -o v -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name))
         self.ssh.run_command(
-            'migrlpar -o m -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name))
+            'migrlpar -o m -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name), timeout=180)
         if self.is_lpar_in_managed_system(dest_mg_system):
             log.info("Migration of lpar %s from %s to %s is successfull" % 
                      (self.lpar_name, src_mg_system, dest_mg_system))


### PR DESCRIPTION
 Prerequisites check for LPM test and added timeout for migration

The following issues are addressed

1. Overide default timeout to that of ideal value for migration
2. Check for required packages installed for migration
3. Disable firewall before starting the migration.
   Using teardown function to enable firewall.
4. Start the rsct services before migration.:

Signed-off-by: Hariharan T.S <harihare@in.ibm.com>