### PR TITLE
OpTestUtil.py: Increase login expect timeout

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1281,7 +1281,7 @@ class OpTestUtil():
                 pty.sendline(my_pwd)
                 time.sleep(0.5)
                 rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~ #",
-                                 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=10)
+                                 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=60)
                 if rc not in [1, 2, 3, 4]:
                     if term_obj.setup_term_quiet == 0:
                         log.warning("OpTestSystem Problem with the login and/or password prompt,"


### PR DESCRIPTION
Sometimes the login prompt takes more time to login and the times out
before expecting last login: prompt, so increased the timeout

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>