### PR TITLE
InstallUpstreamKernel.py: add timeout value

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -90,7 +90,7 @@ class InstallUpstreamKernel(unittest.TestCase):
             con.run_command("[ -d %s ] || mkdir -p %s" %
                             (self.home, self.home))
             con.run_command("if [ -d %s ];then rm -rf %s;fi" %
-                            (linux_path, linux_path))
+                            (linux_path, linux_path), timeout=120))
             con.run_command("cd %s && git clone --depth 1  %s -b %s linux" %
                             (self.home, self.repo, self.branch), timeout=self.host_cmd_timeout)
             con.run_command("cd %s" % linux_path)


### PR DESCRIPTION
the rm command takes more time if the linux source file is too big
and timesout with default 60s, so added timeout with increase time

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>