### PR TITLE
Increase stall time by 2 secs

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -39,7 +39,7 @@ log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 WAITTIME = 15
 BOOTTIME = 500
-STALLTIME = 3
+STALLTIME = 5
 
 
 class OpHmcState():


### PR DESCRIPTION
In case of slow network connectivity the response to console
commands are little late, so increasing wait between the console
commands will solve multiple timing issues

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>