### PR TITLE
InstallUpstreamKernel - Fix syntax error 

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -90,7 +90,7 @@ class InstallUpstreamKernel(unittest.TestCase):
             con.run_command("[ -d %s ] || mkdir -p %s" %
                             (self.home, self.home))
             con.run_command("if [ -d %s ];then rm -rf %s;fi" %
-                            (linux_path, linux_path), timeout=120))
+                            (linux_path, linux_path), timeout=120)
             con.run_command("cd %s && git clone --depth 1  %s -b %s linux" %
                             (self.home, self.repo, self.branch), timeout=self.host_cmd_timeout)
             con.run_command("cd %s" % linux_path)


### PR DESCRIPTION
commit 22ce7b0e8e0d InstallUpstreamKernel.py: add timeout value 
introduced a timeout value to fix a problem while removing large source
files. Unfortunately it introduced following error due to extra paranthesis

Traceback (most recent call last):
  File "./op-test", line 37, in <module>
    from testcases import InstallUpstreamKernel
  File "/home/jenkins/workspace/UpLiKeROPO/testcases/InstallUpstreamKernel.py", line 93
    (linux_path, linux_path), timeout=120))
                                          ^
SyntaxError: invalid syntax

This patch fixes the issue.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>