### PR TITLE
Added config parameters for dump over network - v4

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -385,6 +385,17 @@ def get_parser():
     kernelcmdgroup.add_argument("--remove-kernel-args",
                                 help="Kernel commandline option to be removed",
                                 default="")
+    kdumpgroup = parser.add_argument_group("Kdump group",
+                                           "Ipaddress username and password of remote server")
+    kdumpgroup.add_argument("--dump-server-ip",
+                           help="IP address of remote server where dump will be stored",
+                           default="")
+    kdumpgroup.add_argument("--dump-server-pw",
+                           help="Password of remote server where dump will be stored",
+                           default="")
+    kdumpgroup.add_argument("--dump-path",
+                           help="Directory path of remote server where dump will be stored",
+                           default="/var/crash")
     cronusgroup = parser.add_argument_group("Cronus", "Cronus Config options")
     cronusgroup.add_argument(
         "--cronus-release", default="auto", help="Cronus Release")


### PR DESCRIPTION
Have used these parameters in dump over ssh and nfs in PowerNVDump.py.

Changed --server-ip to --dump-server-ip and --server-pw to --dump-server-pw as suggested in previous PR.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>