### PR TITLE
InstallUpstreamKernel: Increase timeout value in pty.expect() comand for "login:"

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -513,7 +513,7 @@ class HMCConsole(HMCUtil):
             self.util.clear_state(self)
             self.connect(logger=logger)
             time.sleep(STALLTIME)
-            l_rc = self.pty.expect(["login:", pexpect.TIMEOUT], timeout=WAITTIME)
+            l_rc = self.pty.expect(["login:", pexpect.TIMEOUT], timeout=30)
             if l_rc == 0:
                 self.pty.send('\r')
             else:


### PR DESCRIPTION
On some HMC controlled systems, InstallUpstreamKernel testcase gets stuck
at get_console() just after executing kexec -l command.

xxxxxx login:

Red Hat Enterprise Linux 8.4 (Ootpa)
Kernel 4.18.0-305.el8.ppc64le on an ppc64le

Activate the web console with: systemctl enable --now cockpit.socket

xxxxxxx login:

The timeout value of 10 seconds in pty.expect() comand for "login:" is not sufficient.

Increase the timeout to 60.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>