### PR TITLE
Prerequisites check for LPM test and added timeout for migration

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -250,7 +250,7 @@ class HMCUtil():
         lpar_list = self.ssh.run_command(
                    'lssyscfg -r lpar -m %s -F name' % mg_system)
         if self.lpar_name in lpar_list:
-            log.info("%s lpar found in managed system %s" % (mg_system, self.lpar_name))
+            log.info("%s lpar found in managed system %s" % (self.lpar_name, mg_system))
             return True
         return False
 
@@ -262,7 +262,7 @@ class HMCUtil():
         self.ssh.run_command(
             'migrlpar -o v -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name))
         self.ssh.run_command(
-            'migrlpar -o m -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name))
+            'migrlpar -o m -m %s -t %s -p %s' % (src_mg_system, dest_mg_system, self.lpar_name), timeout=180)
         if self.is_lpar_in_managed_system(dest_mg_system):
             log.info("Migration of lpar %s from %s to %s is successfull" % 
                      (self.lpar_name, src_mg_system, dest_mg_system))

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -35,6 +35,8 @@ import OpTestConfiguration
 import OpTestLogger
 from common import OpTestHMC
 from common.OpTestSystem import OpSystemState
+from common.OpTestError import OpTestError
+from common.Exceptions import CommandFailed
 
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
@@ -44,11 +46,45 @@ class OpTestLPM(unittest.TestCase):
         conf = OpTestConfiguration.conf
         self.cv_SYSTEM = conf.system()
         self.console = self.cv_SYSTEM.console
+        self.cv_HOST = conf.host()
         self.cv_HMC = self.cv_SYSTEM.hmc
         self.src_mg_sys = self.cv_HMC.mg_system
         self.dest_mg_sys = self.cv_HMC.tgt_mg_system
+        self.oslevel = None
+
+    def check_pkg_installation(self):
+        pkg_found = True
+        pkg_notfound= []
+        self.oslevel = self.cv_HOST.host_get_OS_Level()
+        lpm_pkg_list = ["src", "rsct.core", "rsct.core.utils", "rsct.basic", "rsct.opt.storagerm", "DynamicRM"]
+        for pkg in lpm_pkg_list:
+            pkg_status = self.cv_HOST.host_check_pkg_installed(self.oslevel, pkg)
+            if not pkg_status:
+                pkg_found = False
+                pkg_notfound.append(pkg)
+        if pkg_found:
+            return True
+        raise OpTestError("Install the required packages : %s" % pkg_notfound)
+
+    def lpm_setup(self):
+        try:
+            self.cv_HOST.host_run_command("systemctl status firewalld.service")
+            self.firewall_status = True
+        except CommandFailed as cf:
+            if cf.exitcode == 3:
+                self.firewall_status = False
+        if self.firewall_status:
+             self.cv_HOST.host_run_command("systemctl stop firewalld.service")
+        rc = self.cv_HOST.host_run_command("lssrc -a | grep 'rsct \| rsct_rm'")
+        if "inoperative" in str(rc):
+            self.cv_HOST.host_run_command("startsrc -g rsct_rm; startsrc -g rsct")
+            rc = self.cv_HOST.host_run_command("lssrc -a")
+            if "inoperative" in str(rc):
+                raise OpTestError("LPM cannot continue as some of rsct services are not active")
 
     def lpar_migrate_test(self):
+        self.check_pkg_installation()
+        self.lpm_setup()
         if not self.cv_HMC.migrate_lpar(self.src_mg_sys, self.dest_mg_sys):
             raise OpTestError("Lpar Migration failed")
         log.debug("Wait for 5 minutes before migrating lpar back") 
@@ -59,3 +95,7 @@ class OpTestLPM(unittest.TestCase):
 
     def runTest(self):
         self.lpar_migrate_test()
+
+    def tearDown(self):
+        if self.firewall_status:
+            self.cv_HOST.host_run_command("systemctl start firewalld.service")


### PR DESCRIPTION
The following issues are addressed

1. Overide default timeout to that of ideal value for migration
2. Check for required packages installed for migration
3. Disable firewall before starting the migration.
   Using teardown function to enable firewall.
4. Start the rsct services before migration.:

Signed-off-by: Hariharan T.S <harihare@in.ibm.com>