### PR TITLE
Fixed failure due to timeout.

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -556,6 +556,8 @@ class OpTestSystem(object):
             # check console type and pass 5 to skip SMS menu when booting an LPAR
             if isinstance(self.console, OpTestHMC.HMCConsole) and x == 1:
                 sys_pty.sendline('5')
+                sys_pty.sendline()
+                time.sleep(80)
             r = sys_pty.expect(expect_seq, kwargs['timeout'])
             # if we have a stale buffer and we are still timing out
             if (previous_before == sys_pty.before) and ((r + 1) in range(len(base_seq))):

--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -286,7 +286,7 @@ class PowerNVDump(unittest.TestCase):
             self.c.pty.sendline("echo c > /proc/sysrq-trigger")
         elif crash_type == "hmc":
             self.cv_HMC.run_command("chsysstate -r lpar -m %s -n %s -o dumprestart" %
-                                   (self.system_name, self.lpar_name))
+                                   (self.system_name, self.lpar_name), timeout=300)
         done = False
         boot_type = BootType.NORMAL
         rc = -1


### PR DESCRIPTION
Added timeout for dumprestart command and delay during login retry on lpar

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>