### PR TITLE
Use SHA256 instead of SHA1 for ipmi server connection algorithm

### DIFF
--- a/common/OpTestIPMI.py
+++ b/common/OpTestIPMI.py
@@ -65,7 +65,7 @@ class IPMITool():
     the caller.
     '''
 
-    def __init__(self, method='lanplus', binary='ipmitool',
+    def __init__(self, method='lanplus', binary='ipmitool', alg_id='17',
                  ip=None, username=None, password=None, logfile=sys.stdout):
         self.method = 'lanplus'
         self.ip = ip
@@ -73,12 +73,13 @@ class IPMITool():
         self.password = password
         self.binary = binary
         self.logfile = logfile
+        self.alg_id = alg_id
 
     def binary_name(self):
         return self.binary
 
     def arguments(self):
-        s = ' -H %s -I %s' % (self.ip, self.method)
+        s = ' -H %s -I %s -C %s' % (self.ip, self.method, self.alg_id)
         if self.username:
             s += ' -U %s' % (self.username)
         if self.password:


### PR DESCRIPTION
Hello,

I was having trouble running tests due to all `ipmitool` commands returning "invalid authentication algorithm". Apparently, `ipmitool` defaults to algorithms that use SHA1. It seems that openBMC has recently [stopped supporting SHA1](https://github.com/openbmc/openbmc/commit/a95e4a952c182380b98edcd8d4f615faabb8af95) . I was able to fix my issue by using `-C 17` (AES with HMAC-SHA256) in my `ipmitool` commands. I figure it is worth implementing across all `ipmitool` commands since I cannot think of anyone who would rather use a different cipher-suite. If I am wrong, then I can work on making it a config option. Until then, I propose using HMAC-SHA256 for all ipmi connections. It looks like `ipmitool` will be [changing there](https://github.com/ipmitool/ipmitool/commit/7772254b62826b894ca629df8c597030a98f4f72) behavior in the coming release. Until then though, I believe this issue will persist as more BMC's are updated to drop support for SHA1.

Please let me know if there is anything I am missing or if I should take any further actions. 
Thanks!