### PR TITLE
common/OpTestHMC: Rectify exit condition logic for wait lpar/system state

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -255,7 +255,7 @@ class HMCUtil():
             state = self.get_lpar_state(vios)
             log.info("Current state: %s", state)
             time.sleep(timeout)
-            count = 1
+            count += 1
             if count > 120:
                 raise OpTestError("Time exceeded for reaching %s" % exp_state)
 
@@ -266,7 +266,7 @@ class HMCUtil():
             state = self.get_system_state()
             log.info("Current state: %s", state)
             time.sleep(timeout)
-            count = 1
+            count += 1
             if count > 60:
                 raise OpTestError("Time exceeded for reaching %s" % exp_state)
 


### PR DESCRIPTION
wait_[lpar|system]_state function checks for expected state for an LPAR/System
after a poweron/poweroff (and other similar) operation. These functions have
an exit condition(count variable) for cases where change of state for
LPAR/system fails after certain number of retries.

Unfortunately the counter never gets incremented which results in infinite loop.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>