### PR TITLE
Modified LPM to work with/without VIOS parameters being specified

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -315,6 +315,18 @@ class HMCUtil():
             return line
         return 0
 
+    def is_msp_enabled(self, mg_system, vios_name):
+        '''
+        The function checks if the moving service option is enabled
+        on the given lpar partition.
+        '''
+        cmd = "lssyscfg -m %s -r lpar --filter lpar_names=%s -F msp" % (
+                mg_system, vios_name)
+        msp_output = self.ssh.run_command(cmd)
+        if int(msp_output[0]) != 1:
+            return False
+        return True
+
     def run_command_ignore_fail(self, command, timeout=60, retry=0):
         return self.ssh.run_command_ignore_fail(command, timeout*self.timeout_factor, retry)
 

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -52,10 +52,11 @@ class OpTestLPM(unittest.TestCase):
         self.src_mg_sys = self.cv_HMC.mg_system
         self.dest_mg_sys = self.cv_HMC.tgt_mg_system
         self.oslevel = None
-        self.src_lpar_vios = self.cv_HMC.lpar_vios.split(",")
-        self.dest_lpar_vios = conf.args.remote_lpar_vios.split(",")
         self.slot_num = None
         self.options = None
+        if conf.args.lpar_vios and 'remote_lpar_vios' in conf.args:
+            self.src_lpar_vios = self.cv_HMC.lpar_vios.split(",")
+            self.dest_lpar_vios = conf.args.remote_lpar_vios.split(",")
         if 'slot_num' in conf.args:
             self.slot_num = conf.args.slot_num
         if self.slot_num:

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -43,6 +43,12 @@ log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
 class OpTestLPM(unittest.TestCase):
 
+
+    @staticmethod
+    def errMsg(vios_name, mg_system):
+        raise OpTestError("Mover Service Partition (MSP) for VIOS %s" \
+        " (in managed system %s) not enabled" % (vios_name, mg_system))
+
     def setUp(self):
         conf = OpTestConfiguration.conf
         self.cv_SYSTEM = conf.system()
@@ -57,6 +63,12 @@ class OpTestLPM(unittest.TestCase):
         if conf.args.lpar_vios and 'remote_lpar_vios' in conf.args:
             self.src_lpar_vios = self.cv_HMC.lpar_vios.split(",")
             self.dest_lpar_vios = conf.args.remote_lpar_vios.split(",")
+            for vios_name in self.src_lpar_vios:
+                if not self.cv_HMC.is_msp_enabled(self.src_mg_sys, vios_name):
+                    self.errMsg(vios_name, self.src_mg_sys)
+            for vios_name in self.dest_lpar_vios:
+                if not self.cv_HMC.is_msp_enabled(self.dest_mg_sys, vios_name):
+                    self.errMsg(vios_name, self.dest_mg_sys)
         if 'slot_num' in conf.args:
             self.slot_num = conf.args.slot_num
         if self.slot_num:


### PR DESCRIPTION
Basic LPM will run even if user does not specify VIOS parameters (lpar_vios, remote_lpar_vios) in config file.

Logs:
[test-log-with-vios.log](https://github.com/open-power/op-test/files/7947997/test-log-with-vios.log)
[test-log-without-vios.log](https://github.com/open-power/op-test/files/7947998/test-log-without-vios.log)


Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>