### PR TITLE
Check DLPAR pci_id is of ethernet type or fc type

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1116,6 +1116,16 @@ class OpTestUtil():
         except CommandFailed as cf:
             log.debug("configure ip to interface  CommandFailed={}".format(cf))
 
+    def ping_test(self, interface, peer_IP, cv_HOST):
+        """
+        ping test to peer IP address
+        """
+        try:
+            ping_cmd = "ping -I {} {} -c 5".format(interface, peer_IP)
+            cv_HOST.host_run_command(ping_cmd)
+        except CommandFailed as cf:
+            log.debug("ping check to peerIP failed   CommandFailed={}".format(cf))
+
     def build_prompt(self, prompt=None):
         if prompt:
             built_prompt = prompt

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1106,6 +1106,16 @@ class OpTestUtil():
         interface = re.search(r'\benP\w+', str(matching_lines), re.I).group()
         return interface
 
+    def configure_host_ip(self, interface, ip, cv_HOST):
+        """
+        Configure IP address on host
+        """
+        try:
+            ip_config = "ip addr add {}/24 dev {}".format(ip, interface)
+            cv_HOST.host_run_command(ip_config)
+        except CommandFailed as cf:
+            log.debug("configure ip to interface  CommandFailed={}".format(cf))
+
     def build_prompt(self, prompt=None):
         if prompt:
             built_prompt = prompt

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1096,6 +1096,16 @@ class OpTestUtil():
                     var[name] = str(value).rstrip()
                     return var[name]
 
+    def get_interface(self, pci_device, cv_HOST):
+        """
+        Get Interface mapped to PCI device
+        """
+        cmd_output = cv_HOST.host_run_command("ls -la /sys/class/net/")
+        pattern = "{}".format(pci_device)
+        matching_lines = [line for line in cmd_output if pattern in line]
+        interface = re.search(r'\benP\w+', str(matching_lines), re.I).group()
+        return interface
+
     def build_prompt(self, prompt=None):
         if prompt:
             built_prompt = prompt

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1082,6 +1082,20 @@ class OpTestUtil():
             return False
         return True
 
+    def get_pci_type(self, pci_device, cv_HOST):
+        """
+        Get PCI device type
+        """
+        device_file = "cat /sys/class/pci_bus/{}/device/{}/uevent".format(pci_device[0:7], pci_device)
+        device_info = cv_HOST.host_run_command(device_file)
+        var = {}
+        for line in device_info:
+            if "=" in line:
+                name, value = line.split("=")
+                if name == "OF_TYPE":
+                    var[name] = str(value).rstrip()
+                    return var[name]
+
     def build_prompt(self, prompt=None):
         if prompt:
             built_prompt = prompt

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1106,12 +1106,14 @@ class OpTestUtil():
         interface = re.search(r'\benP\w+', str(matching_lines), re.I).group()
         return interface
 
-    def configure_host_ip(self, interface, ip, cv_HOST):
+    def configure_host_ip(self, interface, ip, netmask, cv_HOST):
         """
         Configure IP address on host
         """
         try:
-            ip_config = "ip addr add {}/24 dev {}".format(ip, interface)
+            flush_interface = "ip addr flush {}".format(interface)
+            cv_HOST.host_run_command(flush_interface)
+            ip_config = "ip addr add {}/{} dev {}".format(ip, netmask, interface)
             cv_HOST.host_run_command(ip_config)
         except CommandFailed as cf:
             log.debug("configure ip to interface  CommandFailed={}".format(cf))
@@ -1123,8 +1125,10 @@ class OpTestUtil():
         try:
             ping_cmd = "ping -I {} {} -c 5".format(interface, peer_IP)
             cv_HOST.host_run_command(ping_cmd)
+            return True
         except CommandFailed as cf:
             log.debug("ping check to peerIP failed   CommandFailed={}".format(cf))
+            return False
 
     def build_prompt(self, prompt=None):
         if prompt:


### PR DESCRIPTION
Add new function "check_pci_type"  to OpTestUtil.py  to determine whether the given pci_device is of type ethernet or FC .