### PR TITLE
Used a thread and connect() method to monitor console logs for LPM

### DIFF
--- a/common/OpTestSOL.py
+++ b/common/OpTestSOL.py
@@ -34,9 +34,9 @@ import pexpect
 import os
 
 import OpTestConfiguration
-from .OpTestSystem import OpSystemState
+from . import OpTestSystem
 from .Exceptions import CommandFailed
-from .OpTestIPMI import IPMIConsoleState
+from . import OpTestIPMI
 
 import logging
 from logging.handlers import RotatingFileHandler
@@ -57,7 +57,7 @@ class OpSOLMonitorThread(threading.Thread):
         self.execution_time = execution_time
         conf = OpTestConfiguration.conf
         self.system = conf.system()
-        self.system.goto_state(OpSystemState.OS)
+        self.system.goto_state(OpTestSystem.OpSystemState.OS)
         logfile = os.path.join(conf.output, "console.log")
         self.sol_logger(logfile)
         self.c = self.system.console.get_console(logger=self.logger)


### PR DESCRIPTION
Used a thread to see pre-lpm logs. And used ssh.connect() and
ssh.get_console() after migration. Not able to see logs post-lpm.

Not able to see logs for backward lpm (even with thread).

No errors.

Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>