### PR TITLE
testcases/InstallUpstreamKernel: Use grub2-set-default inplace of grubby

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -118,9 +118,9 @@ class InstallUpstreamKernel(unittest.TestCase):
             if not self.use_kexec:
                 # FIXME: Handle distributions which do not support grub
                 con.run_command(
-                    'grubby --set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`')
-                con.run_command(
                     "grub2-mkconfig  --output=/boot/grub2/grub.cfg")
+                con.run_command(
+                    'grub2-set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`')
                 log.debug("Rebooting after kernel install...")
                 self.console_thread.console_terminate()
                 con.close()


### PR DESCRIPTION
InstallUpstreamKernel testcase relies on grubby command to update boot
loader configuration. On hosts running certain Linux flavours which does
not support this command the test fails with command not found error:

[console-expect]#grubby --set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`
grubby --set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`
bash: grubby: command not found

Use grub2-set-default command to specify the boot order. Also switch the
order of grub2-mkconfig and grub2-set-default commands to ensure that all
installed kernels are accounted for before choosing the default one.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>