### PR TITLE
Log collection, dmesg error parsing, cross HMC LPM with vNIC

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -173,6 +173,8 @@ def get_parser():
                         help="Stop on first failure")
     tgroup.add_argument("--quiet", action='store_true', default=False,
                         help="Don't splat lots of things to the console")
+    tgroup.add_argument("--collect-pre-post-test-logs", action="store_true",
+                        help="Collect logs before and after test")
 
     parser.add_argument("--machine-state", help="Current machine state",
                         choices=['UNKNOWN', 'UNKNOWN_BAD', 'OFF', 'PETITBOOT',

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -26,6 +26,7 @@ import sys
 import time
 import pexpect
 import shlex
+import re
 
 import OpTestLogger
 from common.OpTestError import OpTestError
@@ -387,6 +388,53 @@ class HMCUtil():
         if int(msp_output[0]) != 1:
             return False
         return True
+
+    def gather_logs(self, list_of_files=[], list_of_commands=[],
+                    hmc_hscpe_password=None, remote_hmc=None, output_dir=None):
+        if not output_dir:
+            output_dir = "HMC_Logs_%s" % (time.asctime(time.localtime())).replace(" ", "_")
+        output_dir = os.path.join(self.system.cv_HOST.results_dir, output_dir, "hmc")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        self.__gather_files_logs(list_of_files, remote_hmc, output_dir)
+        self.__gather_command_logs(list_of_commands, hmc_hscpe_password, remote_hmc, output_dir)
+
+    def __gather_files_logs(self, list_of_files=[], remote_hmc=None, output_dir=None):
+        hmc = remote_hmc if remote_hmc else self
+        default_files = ['/var/hsc/log/cimserver.log']
+        list_of_files.extend(default_files)
+
+        try:
+            for file in set(list_of_files):
+                self.util.copyFilesFromDest(hmc.user, hmc.hmc_ip, file, hmc.passwd, output_dir)
+            return True
+        except CommandFailed as cmd_failed:
+            raise cmd_failed
+
+    def __gather_command_logs(self, list_of_commands=[], hmc_hscpe_password=None,
+                              remote_hmc=None, output_dir=None):
+        hmc = remote_hmc if remote_hmc else self
+
+        hmc_hscpe_login = OpTestHMC(hmc.hmc_ip,
+                                    'hscpe', hmc_hscpe_password,
+                                    managed_system=hmc.mg_system,
+                                    lpar_name=hmc.lpar_name,
+                                    logfile=hmc.logfile)
+        hmc_hscpe_login.set_system(hmc.system)
+
+        default_commands = ['lshmc -V', 'pedbg -c -q 4']
+        list_of_commands.extend(default_commands)
+
+        try:
+            for cmd in set(list_of_commands):
+                output = "\n".join(hmc_hscpe_login.run_command(r"%s" % cmd, timeout=1800))
+                filename = "%s.log" % '-'.join((re.sub(r'[^a-zA-Z0-9]', ' ', cmd)).split())
+                filepath = os.path.join(output_dir, filename)
+                with open(filepath, 'w') as f:
+                    f.write(output)
+            return True
+        except CommandFailed as cmd_failed:
+            raise cmd_failed
 
     def run_command_ignore_fail(self, command, timeout=60, retry=0):
         return self.ssh.run_command_ignore_fail(command, timeout*self.timeout_factor, retry)

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1977,6 +1977,48 @@ class OpTestUtil():
 
         return '\n'.join(filter(None, filter(filter_strings, dmesg.splitlines())))
 
+    def gather_os_logs(self, list_of_files=[], list_of_commands=[], output_dir=None):
+        host = self.conf.host()
+        if not output_dir:
+            output_dir = "OS_Logs_%s" % (time.asctime(time.localtime())).replace(" ", "_")
+        output_dir = os.path.join(host.results_dir, output_dir, "os")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        self.__gather_os_files_logs(list_of_files, output_dir)
+        self.__gather_os_command_logs(list_of_commands, output_dir)
+
+    def __gather_os_files_logs(self, list_of_files=[], output_dir=None):
+        host = self.conf.host()
+        default_files = ['/var/log/messages', '/var/log/boot.log']
+        list_of_files.extend(default_files)
+
+        try:
+            host.host_run_command("mkdir -p files")
+            for file in set(list_of_files):
+                fn = "%s.log" % '-'.join(file.strip(os.path.sep).split(os.path.sep))
+                host.host_run_command("cp %s files/%s" % (file, fn))
+            host.copy_files_from_host(sourcepath=output_dir, destpath="files")
+            host.host_run_command("rm -rf files")
+            return True
+        except CommandFailed as cmd_failed:
+            raise cmd_failed
+
+    def __gather_os_command_logs(self, list_of_commands=[], output_dir=None):
+        host = self.conf.host()
+        default_commands = ['dmesg', 'journalctl -a']
+        list_of_commands.extend(default_commands)
+
+        try:
+            host.host_run_command("mkdir -p commands")
+            for cmd in set(list_of_commands):
+                fn = "%s.log" % '-'.join((re.sub(r'[^a-zA-Z0-9]', ' ', cmd)).split())
+                host.host_run_command("%s > commands/%s" % (cmd, fn))
+            host.copy_files_from_host(sourcepath=output_dir, destpath="commands")
+            host.host_run_command("rm -rf commands")
+            return True
+        except CommandFailed as cmd_failed:
+            raise cmd_failed
+
 
 class Server(object):
     '''

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -53,6 +53,7 @@ from .OpTestConstants import OpTestConstants as BMC_CONST
 from .OpTestError import OpTestError
 from .Exceptions import CommandFailed, RecoverFailed, ConsoleSettings
 from .Exceptions import HostLocker, AES, ParameterCheck, HTTPCheck, UnexpectedCase
+from .OpTestVIOS import OpTestVIOS
 
 import logging
 import OpTestLogger
@@ -2019,10 +2020,23 @@ class OpTestUtil():
         except CommandFailed as cmd_failed:
             raise cmd_failed
 
+    def gather_vios_logs(self, vios_ip, vios_username, vios_password, list_of_commands=[], output_dir=None):
+        vios = OpTestVIOS(vios_ip, vios_username, vios_password, conf=self.conf)
+        vios.set_system(self.conf.system())
+        vios.gather_logs(output_dir=output_dir)
+
     def gather_hmc_logs(self, list_of_files=[], list_of_commands=[],
                         remote_hmc=None, hmc_hscpe_password=None, output_dir=None):
         hmc = self.conf.hmc()
         hmc.gather_logs(list_of_files, list_of_commands, hmc_hscpe_password, remote_hmc, output_dir)
+
+    def gather_os_vios_hmc_logs(self, vios_ip, vios_username, vios_password, list_of_vios_commands=[],
+                                list_of_os_files=[], list_of_os_commands=[],
+                                list_of_hmc_files=[], list_of_hmc_commands=[], remote_hmc=None,
+                                hmc_hscpe_password=None, output_dir=None):
+        self.gather_os_logs(list_of_os_files, list_of_os_commands, output_dir=output_dir)
+        self.gather_vios_logs(vios_ip, vios_username, vios_password, output_dir=output_dir)
+        self.gather_hmc_logs(list_of_hmc_files, list_of_hmc_commands, remote_hmc, hmc_hscpe_password, output_dir)
 
 
 class Server(object):

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -2019,6 +2019,11 @@ class OpTestUtil():
         except CommandFailed as cmd_failed:
             raise cmd_failed
 
+    def gather_hmc_logs(self, list_of_files=[], list_of_commands=[],
+                        remote_hmc=None, hmc_hscpe_password=None, output_dir=None):
+        hmc = self.conf.hmc()
+        hmc.gather_logs(list_of_files, list_of_commands, hmc_hscpe_password, remote_hmc, output_dir)
+
 
 class Server(object):
     '''

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1913,6 +1913,70 @@ class OpTestUtil():
             time.sleep(step)
         return None
 
+    def clear_dmesg(self):
+        host = self.conf.host()
+        host.host_run_command("dmesg -C")
+
+    def collect_errors_by_level(self, output_file=None, level_check=5, skip_errors=None):
+        """
+        Verify dmesg having severity level of OS issue(s).
+
+        :param output_file: The file used to save dmesg
+        :type output_file: str
+        :param level_check: level of severity of issues to be checked
+                            1 - emerg
+                            2 - emerg,alert
+                            3 - emerg,alert,crit
+                            4 - emerg,alert,crit,err
+                            5 - emerg,alert,crit,err,warn
+        :type level_check: int
+        :skip_errors: list of dmesg error messages which want skip
+        :type skip_errors: list
+        """
+        host = self.conf.host()
+        dmsg_log = out = ""
+        cmd = "dmesg -T -l %s|grep ." % ",".join(map(str, range(0, int(level_check))))
+        try:
+            out = '\n'.join(host.host_run_command(cmd, timeout=30))
+        except CommandFailed as cmd_failed:
+            if cmd_failed.exitcode == 1 and len(cmd_failed.output) == 0:
+                pass
+            else:
+                raise cmd_failed
+        dmsg_log = self.skip_dmesg_messages(out, skip_errors) if skip_errors else out
+        if dmsg_log:
+            if output_file:
+                output_dir = os.path.join(host.results_dir, "logs", "dmesgError")
+                if not os.path.exists(output_dir):
+                    os.makedirs(output_dir)
+                output_file = os.path.join(output_dir, output_file)
+                with open(output_file, "w+", encoding='utf-8') as log_f:
+                    log_f.write(dmsg_log)
+                err = "Found failures in dmesg. Please check dmesg log %s." % (output_file)
+            else:
+                err = "Found failures in dmesg. Please check debug log."
+                log.debug(dmsg_log)
+            self.gather_os_logs(output_dir=os.path.join("logs", "testFail"))
+            raise OpTestError("Test failed. {}".format(err))
+
+    def skip_dmesg_messages(self, dmesg, skip_messages):
+        """
+        Remove some messages from a dmesg buffer.
+
+        This method will remove some lines in a dmesg buffer if some strings are
+        present. Returning the same buffer, but with less lines (in case of match).
+
+        :dmesg: dmesg messages from which filter should be applied. This
+                must be a decoded output buffer with new lines.
+        :type dmesg: str
+        :skip_messages: list of strings to be removed
+        :type skip_messages: list
+        """
+        def filter_strings(line):
+            return not any([string in line for string in skip_messages])
+
+        return '\n'.join(filter(None, filter(filter_strings, dmesg.splitlines())))
+
 
 class Server(object):
     '''

--- a/common/OpTestVIOS.py
+++ b/common/OpTestVIOS.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# IBM_PROLOG_BEGIN_TAG
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2021
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+#
+
+import os
+import re
+import common
+from common.Exceptions import CommandFailed
+
+class OpTestVIOS():
+
+
+    def __init__(self, vios_ip, vios_username, vios_password, conf=None):
+        self.host = vios_ip
+        self.user = vios_username
+        self.passwd = vios_password
+        self.ssh = common.OpTestSSH.OpTestSSH(vios_ip, vios_username, vios_password)
+        self.conf = conf
+
+    def set_system(self, system):
+        self.ssh.set_system(system)
+
+    def gather_logs(self, list_of_commands=[], output_dir=None):
+        host = self.conf.host()
+        if not output_dir:
+            output_dir = "Vios_Logs_%s" % (time.asctime(time.localtime())).replace(" ", "_")
+        output_dir = os.path.join(host.results_dir, output_dir, "vios")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        default_commands = ['cat /proc/version', 'ioslevel', 'errlog', 'snap']
+        list_of_commands.extend(default_commands)
+
+        try:
+            for cmd in set(list_of_commands):
+                output = "\n".join(self.run_command(r"%s" % cmd, timeout=600))
+                filename = "%s.log" % '-'.join((re.sub(r'[^a-zA-Z0-9]', ' ', cmd)).split())
+                filepath = os.path.join(output_dir, filename)
+                with open(filepath, 'w') as f:
+                    f.write(output)
+            return True
+        except CommandFailed as cmd_failed:
+            raise cmd_failed
+
+    def run_command(self, cmd, timeout=60):
+        return self.ssh.run_command(cmd, timeout)

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -62,6 +62,7 @@ class OpTestLPM(unittest.TestCase):
         self.slot_num = None
         self.options = None
         self.lpm_timeout = int(self.conf.args.lpm_timeout) if 'lpm_timeout' in self.conf.args else 300
+        self.util = OpTestUtil(OpTestConfiguration.conf)
 
     def check_pkg_installation(self):
         pkg_found = True
@@ -97,6 +98,15 @@ class OpTestLPM(unittest.TestCase):
             if "inoperative" in str(rc):
                 raise OpTestError("LPM cannot continue as some of rsct services are not active")
 
+    def check_dmesg_errors(self, output_file=None):
+        skip_errors = ['uevent: failed to send synthetic uevent',
+                       'failed to send uevent',
+                       'registration failed',
+                       'Power-on or device reset occurred',
+                       'mobility: Failed lookup: phandle']
+
+        self.util.collect_errors_by_level(output_file=output_file, skip_errors=skip_errors)
+
     def is_RMCActive(self, mg_system, remote_hmc=None):
         '''
         Get the state of the RMC connection for the given parition
@@ -116,10 +126,10 @@ class OpTestLPM(unittest.TestCase):
         '''
         for svc in ["-z", "-A", "-p"]:
             self.cv_HOST.host_run_command('/opt/rsct/bin/rmcctrl %s' % svc, timeout=120)
-        if not OpTestUtil().wait_for(self.is_RMCActive, timeout=60, args=[mg_system, remote_hmc]):
+        if not self.util.wait_for(self.is_RMCActive, timeout=60, args=[mg_system, remote_hmc]):
             self.cv_HOST.host_run_command('/usr/sbin/rsct/install/bin/recfgct', timeout=120)
             self.cv_HOST.host_run_command('/opt/rsct/bin/rmcctrl -p', timeout=120)
-            if not OpTestUtil().wait_for(self.is_RMCActive, timeout=300, args=[mg_system, remote_hmc]):
+            if not self.util.wait_for(self.is_RMCActive, timeout=300, args=[mg_system, remote_hmc]):
                 raise OpTestError("RMC connection is down!!")
 
     def lpm_failed_error(self, mg_system):
@@ -255,7 +265,7 @@ class OpTestLPM_CrossHMC(OpTestLPM):
                 self.src_mg_sys, self.dest_mg_sys, self.target_hmc_ip,
                 self.target_hmc_username, self.target_hmc_password, timeout=self.lpm_timeout
         )
-        
+
         log.debug("Waiting for %.2f minutes." % (self.lpm_timeout/60))
         time.sleep(self.lpm_timeout)
 

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -51,7 +51,7 @@ class OpTestLPM(unittest.TestCase):
         raise OpTestError("Mover Service Partition (MSP) for VIOS %s" \
         " (in managed system %s) not enabled" % (vios_name, mg_system))
 
-    def setUp(self):
+    def setUp(self, remote_hmc=None):
         self.conf = OpTestConfiguration.conf
         self.cv_SYSTEM = self.conf.system()
         self.console = self.cv_SYSTEM.console
@@ -61,7 +61,7 @@ class OpTestLPM(unittest.TestCase):
         self.dest_mg_sys = self.cv_HMC.tgt_mg_system
         self.oslevel = None
         self.slot_num = None
-        self.options = None
+        self.options = self.conf.args.options if 'options' in self.conf.args else None
         self.lpm_timeout = int(self.conf.args.lpm_timeout) if 'lpm_timeout' in self.conf.args else 300
         self.util = OpTestUtil(OpTestConfiguration.conf)
         if 'hmc_hscpe_password' in self.conf.args:
@@ -70,6 +70,37 @@ class OpTestLPM(unittest.TestCase):
             self.vios_ip = self.conf.args.vios_ip
             self.vios_username = self.conf.args.vios_username
             self.vios_password = self.conf.args.vios_password
+
+        if self.conf.args.lpar_vios and 'remote_lpar_vios' in self.conf.args:
+            self.src_lpar_vios = self.cv_HMC.lpar_vios.split(",")
+            self.dest_lpar_vios = self.conf.args.remote_lpar_vios.split(",")
+            for vios_name in self.src_lpar_vios:
+                if not self.cv_HMC.is_msp_enabled(self.src_mg_sys, vios_name):
+                    self.errMsg(vios_name, self.src_mg_sys)
+            for vios_name in self.dest_lpar_vios:
+                if not self.cv_HMC.is_msp_enabled(self.dest_mg_sys, vios_name, remote_hmc):
+                    self.errMsg(vios_name, self.dest_mg_sys)
+
+        if 'slot_num' in self.conf.args:
+            self.slot_num = self.conf.args.slot_num
+        if self.slot_num:
+            self.bandwidth = self.conf.args.bandwidth
+            self.adapters = self.conf.args.adapters.split(",")
+            self.target_adapters = self.conf.args.target_adapters.split(",")
+            self.ports = self.conf.args.ports.split(",")
+            self.target_ports = self.conf.args.target_ports.split(",")
+            self.vios_id = []
+            for vios_name in self.src_lpar_vios:
+                self.vios_id.append(self.cv_HMC.get_lpar_id(self.src_mg_sys, vios_name))
+            self.target_vios_id = []
+            for vios_name in self.dest_lpar_vios:
+                self.target_vios_id.append(self.cv_HMC.get_lpar_id(self.dest_mg_sys, vios_name, remote_hmc))
+            self.adapter_id = []
+            for adapter in self.adapters:
+                self.adapter_id.append(self.cv_HMC.get_adapter_id(self.src_mg_sys, adapter))
+            self.target_adapter_id = []
+            for adapter in self.target_adapters:
+                self.target_adapter_id.append(self.cv_HMC.get_adapter_id(self.dest_mg_sys, adapter, remote_hmc))
 
     def check_pkg_installation(self):
         pkg_found = True
@@ -104,6 +135,39 @@ class OpTestLPM(unittest.TestCase):
             rc = self.cv_HOST.host_run_command("lssrc -a")
             if "inoperative" in str(rc):
                 raise OpTestError("LPM cannot continue as some of rsct services are not active")
+
+    def vnic_options(self, remote=''):
+        '''
+        Form the vnic_mappings param based on the adapters' details
+        provided.
+        '''
+        if int(self.slot_num) < 3 or int(self.slot_num) > 2999:
+            return ""
+        if remote:
+            cmd = []
+            for index in range(0, len(self.adapters)):
+                l_cmd = []
+                for param in [self.slot_num, 'ded', self.src_lpar_vios[index],
+                              self.vios_id[index], self.adapter_id[index],
+                              self.ports[index], self.bandwidth,
+                              self.target_adapter_id[index],
+                              self.target_ports[index]]:
+                    l_cmd.append(param)
+                cmd.append("/".join(l_cmd))
+        else:
+            cmd = []
+            for index in range(0, len(self.adapters)):
+                l_cmd = []
+                for param in [self.slot_num, 'ded',
+                              self.dest_lpar_vios[index],
+                              self.target_vios_id[index],
+                              self.target_adapter_id[index],
+                              self.target_ports[index], self.bandwidth,
+                              self.adapter_id[index], self.ports[index]]:
+                    l_cmd.append(param)
+                cmd.append("/".join(l_cmd))
+
+        return " -i \"vnic_mappings=%s\" " % ",".join(cmd)
 
     def check_dmesg_errors(self, output_file=None):
         skip_errors = ['uevent: failed to send synthetic uevent',
@@ -156,70 +220,6 @@ class OpTestLPM_LocalHMC(OpTestLPM):
 
     def setUp(self):
         super(OpTestLPM_LocalHMC, self).setUp()
-
-        if self.conf.args.lpar_vios and 'remote_lpar_vios' in self.conf.args:
-            self.src_lpar_vios = self.cv_HMC.lpar_vios.split(",")
-            self.dest_lpar_vios = self.conf.args.remote_lpar_vios.split(",")
-            for vios_name in self.src_lpar_vios:
-                if not self.cv_HMC.is_msp_enabled(self.src_mg_sys, vios_name):
-                    self.errMsg(vios_name, self.src_mg_sys)
-            for vios_name in self.dest_lpar_vios:
-                if not self.cv_HMC.is_msp_enabled(self.dest_mg_sys, vios_name):
-                    self.errMsg(vios_name, self.dest_mg_sys)
-        if 'slot_num' in self.conf.args:
-            self.slot_num = self.conf.args.slot_num
-        if self.slot_num:
-            self.bandwidth = self.conf.args.bandwidth
-            self.options = self.conf.args.options
-            self.adapters = self.conf.args.adapters.split(",")
-            self.target_adapters = self.conf.args.target_adapters.split(",")
-            self.ports = self.conf.args.ports.split(",")
-            self.target_ports = self.conf.args.target_ports.split(",")
-            self.vios_id = []
-            for vios_name in self.src_lpar_vios:
-                self.vios_id.append(self.cv_HMC.get_lpar_id(self.src_mg_sys, vios_name))
-            self.target_vios_id = []
-            for vios_name in self.dest_lpar_vios:
-                self.target_vios_id.append(self.cv_HMC.get_lpar_id(self.dest_mg_sys, vios_name))
-            self.adapter_id = []
-            for adapter in self.adapters:
-                self.adapter_id.append(self.cv_HMC.get_adapter_id(self.src_mg_sys, adapter))
-            self.target_adapter_id = []
-            for adapter in self.target_adapters:
-                self.target_adapter_id.append(self.cv_HMC.get_adapter_id(self.dest_mg_sys, adapter))
-
-    def vnic_options(self, remote=''):
-        '''
-        Form the vnic_mappings param based on the adapters' details
-        provided.
-        '''
-        if int(self.slot_num) < 3 or int(self.slot_num) > 2999:
-            return ""
-        if remote:
-            cmd = []
-            for index in range(0, len(self.adapters)):
-                l_cmd = []
-                for param in [self.slot_num, 'ded', self.src_lpar_vios[index],
-                              self.vios_id[index], self.adapter_id[index],
-                              self.ports[index], self.bandwidth,
-                              self.target_adapter_id[index],
-                              self.target_ports[index]]:
-                    l_cmd.append(param)
-                cmd.append("/".join(l_cmd))
-        else:
-            cmd = []
-            for index in range(0, len(self.adapters)):
-                l_cmd = []
-                for param in [self.slot_num, 'ded',
-                              self.dest_lpar_vios[index],
-                              self.target_vios_id[index],
-                              self.target_adapter_id[index],
-                              self.target_ports[index], self.bandwidth,
-                              self.adapter_id[index], self.ports[index]]:
-                    l_cmd.append(param)
-                cmd.append("/".join(l_cmd))
-
-        return " -i \"vnic_mappings=%s\" " % ",".join(cmd)
 
     def lpar_migrate_test(self):
         self.util.clear_dmesg()
@@ -279,13 +279,14 @@ class OpTestLPM_CrossHMC(OpTestLPM):
 
 
     def setUp(self):
-        super(OpTestLPM_CrossHMC, self).setUp()
+        self.conf = OpTestConfiguration.conf
 
         # The following variables needs to be defined in
         # ~/.op-test-framework.conf
         self.target_hmc_ip = self.conf.args.target_hmc_ip
         self.target_hmc_username = self.conf.args.target_hmc_username
         self.target_hmc_password = self.conf.args.target_hmc_password
+
         if 'remote_hmc_hscpe_password' in self.conf.args:
             self.remote_hmc_hscpe_password = self.conf.args.remote_hmc_hscpe_password
         if all(v in self.conf.args for v in ['remote_vios_ip', 'remote_vios_username',
@@ -293,6 +294,17 @@ class OpTestLPM_CrossHMC(OpTestLPM):
             self.remote_vios_ip = self.conf.args.remote_vios_ip
             self.remote_vios_username = self.conf.args.remote_vios_username
             self.remote_vios_password = self.conf.args.remote_vios_password
+
+        self.remote_hmc = OpTestHMC.OpTestHMC(self.target_hmc_ip,
+                                              self.target_hmc_username,
+                                              self.target_hmc_password,
+                                              managed_system=self.conf.args.target_system_name,
+                                              lpar_name=self.conf.args.remote_lpar_vios,
+                                              lpar_user=self.conf.args.remote_vios_username,
+                                              lpar_password=self.conf.args.remote_vios_password)
+        self.remote_hmc.set_system(self.conf.system())
+
+        super(OpTestLPM_CrossHMC, self).setUp(self.remote_hmc)
 
     def cross_hmc_migrate_test(self):
         self.util.clear_dmesg()
@@ -308,35 +320,34 @@ class OpTestLPM_CrossHMC(OpTestLPM):
                                           output_dir=os.path.join("logs", "test", "preForwardLPM"))
         self.check_dmesg_errors(output_file="preForwardLPM")
 
+        cmd = ''
+        if self.slot_num:
+            cmd = self.vnic_options()
         self.cv_HMC.cross_hmc_migration(
                 self.src_mg_sys, self.dest_mg_sys, self.target_hmc_ip,
-                self.target_hmc_username, self.target_hmc_password, timeout=self.lpm_timeout
+                self.target_hmc_username, self.target_hmc_password,
+                options=self.options, param=cmd, timeout=self.lpm_timeout
         )
 
         log.debug("Waiting for %.2f minutes." % (self.lpm_timeout/60))
         time.sleep(self.lpm_timeout)
 
-        remote_hmc = OpTestHMC.OpTestHMC(self.target_hmc_ip,
-                                         self.target_hmc_username,
-                                         self.target_hmc_password,
-                                         managed_system=self.dest_mg_sys,
-                                         lpar_name=self.cv_HMC.lpar_name,
-                                         logfile=self.cv_HMC.logfile)
-        remote_hmc.set_system(self.cv_SYSTEM)
-
         self.util.gather_os_vios_hmc_logs(self.remote_vios_ip, self.remote_vios_username,
-                                          self.remote_vios_password, remote_hmc=remote_hmc,
+                                          self.remote_vios_password, remote_hmc=self.remote_hmc,
                                           hmc_hscpe_password=self.remote_hmc_hscpe_password,
                                           output_dir=os.path.join("logs", "test", "postForwardLPM"))
         self.check_dmesg_errors(output_file="postForwardLPM")
 
-        if not self.is_RMCActive(self.dest_mg_sys, remote_hmc):
+        if not self.is_RMCActive(self.dest_mg_sys, self.remote_hmc):
             log.info("RMC service is inactive..!")
-            self.rmc_service_start(self.dest_mg_sys, remote_hmc)
+            self.rmc_service_start(self.dest_mg_sys, self.remote_hmc)
 
+        if self.slot_num:
+            cmd = self.vnic_options('remote')
         self.cv_HMC.cross_hmc_migration(
                 self.dest_mg_sys, self.src_mg_sys, self.cv_HMC.hmc_ip,
-                self.cv_HMC.user, self.cv_HMC.passwd, remote_hmc, timeout=self.lpm_timeout
+                self.cv_HMC.user, self.cv_HMC.passwd, self.remote_hmc,
+                options=self.options, param=cmd, timeout=self.lpm_timeout
         )
 
         self.util.gather_os_vios_hmc_logs(self.vios_ip, self.vios_username,


### PR DESCRIPTION
Defined a command-line argument (--collect-pre-post-test-logs) that needs to be specified if user wishes to collect logs before and after test.

Defined functions for collecting OS, VIOS, HMC logs. Logs are collected at different stages:
- before and after test
- within test: pre-forward lpm, post-forward lpm, post-backward lpm

Defined functions to parse dmesg for errors.