### PR TITLE
testcases/InstallUpstreamKernel: grub and kexec handling fixes

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -120,7 +120,7 @@ class InstallUpstreamKernel(unittest.TestCase):
                 con.run_command(
                     "grub2-mkconfig  --output=/boot/grub2/grub.cfg")
                 con.run_command(
-                    'grub2-set-default /boot/vmlinuz-`cat include/config/kernel.release 2> /dev/null`')
+                    'grub2-set-default /boot/vmlinu*-`cat include/config/kernel.release 2> /dev/null`')
                 log.debug("Rebooting after kernel install...")
                 self.console_thread.console_terminate()
                 con.close()
@@ -133,14 +133,18 @@ class InstallUpstreamKernel(unittest.TestCase):
                     cmdline += " %s" % self.append_kernel_cmdline
                 kern_rel_str = con.run_command(
                     "cat %s/include/config/kernel.release" % linux_path)[-1]
-                initrd_file = con.run_command(
-                    "ls -l /boot/initr*-%s.img" % kern_rel_str)[-1].split(" ")[-1]
-                kexec_cmdline = "kexec --initrd %s --command-line=\"%s\" /boot/vmlinuz-%s -l" % (
+                try:
+                    initrd_file = con.run_command(
+                        "ls -l /boot/initr*-%s.img" % kern_rel_str)[-1].split(" ")[-1]
+                except Exception:
+                    initrd_file = con.run_command(
+                        "ls -l /boot/initr*-%s" % kern_rel_str)[-1].split(" ")[-1]
+                kexec_cmdline = "kexec --initrd %s --command-line=\"%s\" /boot/vmlinu*-%s -l" % (
                     initrd_file, cmdline, kern_rel_str)
                 # Let's makesure we set the default boot index to current kernel
                 # to avoid leaving host in unstable state incase boot failure
                 con.run_command(
-                    'grubby --set-default /boot/vmlinuz-`uname -r 2> /dev/null`')
+                    'grub2-set-default /boot/vmlinu*-`uname -r 2> /dev/null`')
                 con.run_command(kexec_cmdline)
                 con.close()
                 raw_pty = self.cv_SYSTEM.console.get_console()

--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -148,7 +148,7 @@ class InstallUpstreamKernel(unittest.TestCase):
                 con.run_command(kexec_cmdline)
                 con.close()
                 raw_pty = self.cv_SYSTEM.console.get_console()
-                raw_pty.sendline("kexec -e")
+                raw_pty.sendline("reboot")
                 raw_pty.expect("login:", timeout=600)
             con = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
             res = con.run_command("uname -r")


### PR DESCRIPTION
testcases/InstallUpstreamKernel: Replace remaining instances of grubby
commit 258fb8545f1f switched from grubby to grub2-set-default command.
This change was done only for non kexec use case. Switch to using the same
command for use_kexec case as well.

testcases/InstallUpstreamKernel: Perform a clean kexec reboot
kexec -l / kexec -e sequence is prone to failures since it does not go through
a clean shutdown/reboot. The recommended way is to either use kexec
without -l option avoiding use of another follow-up kexec command or use
kexec -l with reboot. Both these methods ensures a clean boot on kexec.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>