### PR TITLE
Added provision for Kdump (NFS and SSH) over Private IP

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -55,6 +55,8 @@
 #      and verify boot progress and collected dump components
 #      (vmcore and opalcore).
 #
+#   NOTE: For remote kdump, network to be configured manually via static sysfs IP, before test starts.
+#
 
 import os
 import pexpect


### PR DESCRIPTION
Takes care of configuration of IP, and performs kdump over private IP (both SSH and NFS).

Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>