### PR TITLE
Logs warnings to collect pedbg and snap logs manually

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -407,6 +407,7 @@ class HMCUtil():
                 filepath = os.path.join(output_dir, filename)
                 with open(filepath, 'w') as f:
                     f.write(output)
+            log.warn("Please collect the pedbg logs immediately. At risk of being overwritten.")
             return True
         except CommandFailed as cmd_failed:
             raise cmd_failed

--- a/common/OpTestVIOS.py
+++ b/common/OpTestVIOS.py
@@ -63,7 +63,7 @@ class OpTestVIOS():
                     f.write(output)
             snap_backup_filename = time.strftime("%d_%m_%Y_%H_%M_%S") + "_snap.pax.Z"
             self.run_command("mv snap.pax.Z %s" % snap_backup_filename)
-            log.info("snap.pax.Z renamed to %s" % snap_backup_filename)
+            log.warn("Please collect the snap logs. snap.pax.Z renamed to %s." % snap_backup_filename)
             return True
         except CommandFailed as cmd_failed:
             raise cmd_failed


### PR DESCRIPTION
Logs a warning to collect the snap logs (which has been renamed) and
the pedbg logs.

Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>