### PR TITLE
Added provision for inactive LPM

### DIFF
--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -236,7 +236,7 @@ class OpTestLPM(unittest.TestCase):
         hmc = remote_hmc if remote_hmc else self.cv_HMC
         cmd = "diagrmc -m %s --ip %s -p %s --autocorrect" % (
             mg_system, self.cv_HOST.ip, self.cv_HMC.lpar_name)
-        output = hmc.ssh.run_command(cmd, timeout=300)
+        output = hmc.ssh.run_command(cmd, timeout=600)
         for line in output:
             if "%s has RMC connection." % self.cv_HOST.ip in line:
                 return True


### PR DESCRIPTION
- To perform inactive LPM, a boolean value can be provided in the
config file using parameter "inactive_lpm"

- System powered off before migration, and powered on upon completion
of migration.

- No OS logs are collected and no dmesg error checking is performed
if inactive LPM is performed.

Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>