### PR TITLE
Add an option to run single or remote with lpm suite

### DIFF
--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -499,6 +499,8 @@ class OpTestLPM_CrossHMC(OpTestLPM):
 
 def LPM_suite():
     s = unittest.TestSuite()
-    s.addTest(OpTestLPM_LocalHMC())
-    s.addTest(OpTestLPM_CrossHMC())
+    if conf.args.target_hmc_ip:
+        s.addTest(OpTestLPM_CrossHMC())
+    else:
+        s.addTest(OpTestLPM_LocalHMC())
     return s


### PR DESCRIPTION
Based on user input conf, test decide whether to run local hmc
test or remote hmc test, so user can call same lpm-suite name
for both scenarios

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>