### PR TITLE
Update lpm-suite to run single or remote hmc test

### DIFF
--- a/op-test
+++ b/op-test
@@ -657,9 +657,17 @@ class DlparIOSuite():
 
 class LPMSuite():
     '''LPM Test Suite'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        if 'target_hmc_ip' in OpTestConfiguration.conf.args:
+            optestlog.info('Running Remote HMC tests')
+            self.s.addTest(OpTestLPM.OpTestLPM_CrossHMC())
+        else:
+            optestlog.info('Running Local HMC tests')
+            self.s.addTest(OpTestLPM.OpTestLPM_LocalHMC())
 
     def suite(self):
-        return OpTestLPM.LPM_suite()
+        return self.s
 
 class FspOpalSuite():
     def __init__(self):

--- a/testcases/OpTestLPM.py
+++ b/testcases/OpTestLPM.py
@@ -495,10 +495,3 @@ class OpTestLPM_CrossHMC(OpTestLPM):
         if self.stressng_command and self.thread_stressng.isAlive():
             self.cv_HOST.host_run_command('pkill -x "stress-ng"')
             self.thread_stressng.console_terminate()
-
-
-def LPM_suite():
-    s = unittest.TestSuite()
-    s.addTest(OpTestLPM_LocalHMC())
-    s.addTest(OpTestLPM_CrossHMC())
-    return s


### PR DESCRIPTION
Based on user input i.e target_hmc_ip in conf, suite
decide whether to run local hmc or remote hmc test
Also removed the suite from inside the test

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>