### PR TITLE
Update osdump-suite to run as per user input

### DIFF
--- a/op-test
+++ b/op-test
@@ -640,11 +640,13 @@ class OSdumpSuite():
         self.s.addTest(PowerNVDump.KernelCrash_OnlyKdumpEnable())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpSSH())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpNFS())
-        self.s.addTest(PowerNVDump.KernelCrash_KdumpSAN())
+        if 'dev_path' in OpTestConfiguration.conf.args:
+            self.s.addTest(PowerNVDump.KernelCrash_KdumpSAN())
         self.s.addTest(PowerNVDump.KernelCrash_FadumpEnable())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpSSH())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpNFS())
-        self.s.addTest(PowerNVDump.KernelCrash_KdumpSAN())
+        if 'dev_path' in OpTestConfiguration.conf.args:
+            self.s.addTest(PowerNVDump.KernelCrash_KdumpSAN())
 
     def suite(self):
         return self.s


### PR DESCRIPTION
Make sure kdump over disk is run only if dev_path is given
do not fail network dump if dev_path is not given

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>