### PR TITLE
Error handling if OS file log not present

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -2004,7 +2004,8 @@ class OpTestUtil():
             host.host_run_command("mkdir -p files")
             for file in set(list_of_files):
                 fn = "%s.log" % '-'.join(file.strip(os.path.sep).split(os.path.sep))
-                host.host_run_command("cp %s files/%s" % (file, fn))
+                host.host_run_command("[ -f %s ] && { cp %s files/%s; } || "
+                                      "echo 'File does not exist'" % (file, file, fn))
             host.copy_files_from_host(sourcepath=output_dir, destpath="files")
             host.host_run_command("rm -rf files")
             return True


### PR DESCRIPTION
If the log file is not present, no error is thrown.

Signed-off-by: rashijhawar <rashi@linux.vnet.ibm.com>