### PR TITLE
op-test/common: Skip fsp_get_console call

### DIFF
--- a/common/OpTestSystem.py
+++ b/common/OpTestSystem.py
@@ -1393,7 +1393,6 @@ class OpTestLPARSystem(OpTestSystem):
                  bmc=None,
                  conf=None,
                  state=OpSystemState.UNKNOWN):
-        bmc.fsp_get_console()
         self.hmc = bmc.get_hmc()
         super(OpTestLPARSystem, self).__init__(host=host,
                                               bmc=bmc,


### PR DESCRIPTION
OpTestLPARSystem iniitalization includes a call to fsp_get_console. This function call disables firewall, opens a connection to FSP and records its hostname. This call isn't necessary for LPAR based system and possibly was inherited from OpTestFSPSystem class.

Don't call this function so that it does not alter the FSP configuration(iptable rules).

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>