### PR TITLE
OpTestHMC/OpTestKexec : Enable secureboot pre-requisites

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -55,6 +55,43 @@ SYS_WAITTIME = 200
 BOOTTIME = 500
 STALLTIME = 5
 
+class OpSecureBootUtilities():
+    '''
+    This class addresses the secureboot related pre-requisites.
+    '''
+
+    def __init__(self, console=None, distro=None):
+        self.console = console
+        self.distro = distro
+
+    def check_kernel_signature(self):
+        '''
+        Check whether the kernel is signed or unsigned.
+        If, string - "Module signature appended" is found,
+        then the kernel is signed, else, the kernel is unsigned.
+        '''
+        vmlinux = "vmlinuz"  # RHEL
+        if self.distro == 'SLES' or self.distro == "suse":
+            vmlinux = "vmlinux"
+
+        cmd = "strings /boot/%s-$(uname -r) | tail -1" % vmlinux
+        output = self.console.run_command(cmd)
+        if "Module signature appended" in output[0]:
+            return "signed_kernel"
+        return "unsigned_kernel"
+
+    def check_os_level_secureboot_state(self):
+        '''
+        Check whether the secure-boot is enabled at os level.
+        To do this, check the entry of "00000002" in "/proc/device-tree/ibm,secure-boot" file.
+        If found, then secure-boot is enabled.
+        '''
+        cmd = "lsprop /proc/device-tree/ibm,secure-boot"
+        output = self.console.run_command(cmd)
+        for line in output:
+            if '00000002' in line:
+                return True
+        return False
 
 class OpHmcState():
     '''

--- a/testcases/OpTestKexec.py
+++ b/testcases/OpTestKexec.py
@@ -41,6 +41,7 @@ import OpTestConfiguration
 from common.OpTestSystem import OpSystemState
 from common.Exceptions import CommandFailed
 from common.OpTestError import OpTestError
+from common.OpTestHMC import OpSecureBootUtilities
 
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
@@ -84,6 +85,10 @@ class OpTestKexec(unittest.TestCase):
                 self.initrd_image = "initrd.img-{}".format(kernel_release)
             else:
                 log.info("Distro not supported")
+
+        sb_utilities = OpSecureBootUtilities(self.c, self.distro)
+        self.kernel_signature = sb_utilities.check_kernel_signature()
+        self.os_level_secureboot = sb_utilities.check_os_level_secureboot_state()
 
     def get_raw_pty_console(self,cmd):
         """


### PR DESCRIPTION
OpTestHMC is added with a new class "OpSecureBootUtilities" which will incorporate all the common required secureboot related APIs as pre-requisites. This commit addresses two API additions as of now -
1. check_kernel_signature()
2. check_os_level_secureboot_state()

OpTestKexec is changed to handle the returned values from the above two APIs which would be required further to handle secureboot enabled kexec operations.