### PR TITLE
Reset unique prompt for multi reboot usecases

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -895,6 +895,10 @@ class HMCConsole(HMCUtil):
             l_rc = self.pty.expect(["login:", pexpect.TIMEOUT], timeout=30)
             if l_rc == 0:
                 self.pty.send('\r')
+                # In case when OS reboot/multireboot test and we lose prompt, reset prompt
+                self.system.LOGIN_set = -1
+                self.system.PS1_set = -1
+                self.system.SUDO_set = -1
             else:
                 time.sleep(STALLTIME)
                 self.pty.send('\r')


### PR DESCRIPTION
While working with multiple reboot tests, the test requires to login and set unique prompt multiple times, so currently the raw pty console get_console is designed to work for one time login, so when OS reboot happens in mid of test, this requires to reset prompt, sudo, login parameters, setup_term can reset the prompt post login and continue test flow