### PR TITLE
upstreaminstall: add missing re module import

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -20,6 +20,7 @@
 
 import unittest
 import os
+import re
 
 try:
     from urllib.parse import urlparse


### PR DESCRIPTION
In previous commit we are using regex module in the code but we missed importing it