### PR TITLE
run_command issue - Set binding of bracketed packets to off

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1698,6 +1698,7 @@ class OpTestUtil():
         expect_prompt = self.build_prompt(term_obj.prompt) + "$"
         # if previous caller environment leaves buffer hung can show up here, e.g. PS2 prompt
         pty = term_obj.get_console()
+        pty.sendline("bind 'set enable-bracketed-paste off'")
         pty.sendline(command)
         if command == 'sudo -s':
             running_sudo_s = True


### PR DESCRIPTION
In recent pexpect package upgrade, output of pexpect is binded with binary packets due to this the tests were failing while parsing the output of command run via run_command.

Hence adding fix to disable the binding of output packets got via the pexpect will resolve the issue

Signed-off-by: Spoorthy S<spoorts2@in.ibm.com>