### PR TITLE
Enhancing the Lcov.py to copy back the html files of test results

### DIFF
--- a/testcases/Lcov.py
+++ b/testcases/Lcov.py
@@ -118,4 +118,11 @@ class LcovGatherData(LcovSetup):
         self.c.run_command(info_cmd, timeout=self.host_cmd_timeout)
         html_cmd = f'genhtml -o {temp_dir} {info_file_path}'
         self.c.run_command(html_cmd, timeout=self.host_cmd_timeout)
+        curr_dir = os.getcwd()
+        log.info(f"\n\ncurrent_dir={curr_dir}, \ncreating dir here now")
+        self.cv_HOST.host_run_command("mkdir -p Lcov-result")
+        lcov_result_dir = os.path.join(curr_dir, "Lcov-result")
+        log.info(f"copying html files to this paths at source : {lcov_result_dir}")
+        self.cv_HOST.copy_files_from_host(lcov_result_dir, "%s/*" %temp_dir)
+        log.info("\ncopying done.....")
 


### PR DESCRIPTION
This code will copy back the html result file to the source path from where we have triggered the test case.