### PR TITLE
MachineConfig.py : Secureboot config based APIs

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -46,6 +46,7 @@ from common.OpTestError import OpTestError
 from common.OpTestSSH import OpTestSSH
 from common.OpTestUtil import OpTestUtil
 from common.Exceptions import CommandFailed
+#from common.OpTestSystem import OpSystemState
 from common import OPexpect
 
 from .OpTestConstants import OpTestConstants as BMC_CONST
@@ -159,7 +160,7 @@ class HMCUtil():
         self.PS1_set = -1
         self.LOGIN_set = -1
         self.SUDO_set = -1
-
+    
     def check_lpar_secureboot_state(self, hmc_con):
         '''
         Check whether the secure-boot is enabled for lpar.
@@ -174,6 +175,34 @@ class HMCUtil():
         if int(output[0]) == 2: # Value '2' means Secure Boot enabled
             return True
         elif int(output[0]) == 0: # Value '0' means Secure Boot disabled
+            return False
+
+    def hmc_secureboot_on_off(self, enable=True):
+        '''
+        Enable/Disable Secure Boot from HMC
+        1. PowerOFF/Shutdown LPAR from HMC
+        2. Enable/Disable Secure boot using 'chsyscfg' command
+        3. PowerON/Activate the LPAR and boot to Operating System
+        '''
+        # PowerOFF/shutdown LPAR from HMC
+        self.poweroff_lpar()
+        # Set Secure Boot value using HMC command
+        cmd = ('chsyscfg -r lpar -m %s -i "name=%s, secure_boot=' %
+               (self.mg_system, self.lpar_name))
+        if enable: # Value '2' to enable Secure Boot
+            cmd = '%s2"' % cmd
+        else: # Value '0' to disable Secure Boot
+            cmd = '%s0"' % cmd
+        self.ssh.run_command(cmd, timeout=300)
+            # PowerON/Activate LPAR and Boot the Operating System
+        self.poweron_lpar()
+
+        # Checking What Secure Boot state got set,
+        # according to the required enable/disable
+        hmc_secureboot = self.check_lpar_secureboot_state(self.ssh)
+        if (enable and hmc_secureboot) or (not enable and not hmc_secureboot):
+            return True
+        else:
             return False
 
     def deactivate_lpar_console(self):

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -184,8 +184,6 @@ class HMCUtil():
         2. Enable/Disable Secure boot using 'chsyscfg' command
         3. PowerON/Activate the LPAR and boot to Operating System
         '''
-        # PowerOFF/shutdown LPAR from HMC
-        self.poweroff_lpar()
         # Set Secure Boot value using HMC command
         cmd = ('chsyscfg -r lpar -m %s -i "name=%s, secure_boot=' %
                (self.mg_system, self.lpar_name))
@@ -193,17 +191,8 @@ class HMCUtil():
             cmd = '%s2"' % cmd
         else: # Value '0' to disable Secure Boot
             cmd = '%s0"' % cmd
-        self.ssh.run_command(cmd, timeout=300)
-            # PowerON/Activate LPAR and Boot the Operating System
-        self.poweron_lpar()
+        return self.ssh.run_command(cmd, timeout=300)
 
-        # Checking What Secure Boot state got set,
-        # according to the required enable/disable
-        hmc_secureboot = self.check_lpar_secureboot_state(self.ssh)
-        if (enable and hmc_secureboot) or (not enable and not hmc_secureboot):
-            return True
-        else:
-            return False
 
     def deactivate_lpar_console(self):
         '''

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -156,24 +156,6 @@ class OpTestUtil():
                 return True
         return False
 
-    def validate_secureboot_parameter(self, machine_config):
-        '''
-        Checks the validity of the states, set as parameter in the configuration file.
-        Valid states are either 'on' or 'off'.
-        Return : 
-        True  - if secureboot is set to 'on'
-        False - if secureboot is set to 'off' 
-        '''
-        self.sb_valid_states = ['on', 'off']
-        secureboot_parameter_state = re.findall("secureboot=[a-z][a-z]+", str(machine_config))[0].split('=')[1]
-        if str(secureboot_parameter_state) not in self.sb_valid_states:
-            self.skipTest("%s is not a valid state for secureboot. "
-                          "Secureboot valid states can be either set to 'on' or 'off'" % str(secureboot_parameter_state))
-        if secureboot_parameter_state == 'on':
-            return True
-        else:
-            return False
-
     def getPRePDisk(self):
         '''
         Identify the PReP partition, this disk name is required to copy

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -227,6 +227,7 @@ class LparConfig():
 
 
         if "vtpm=1" in self.machine_config:
+            conf = OpTestConfiguration.conf
             vtpm_enabled = self.cv_HMC.vtpm_state()
             if vtpm_enabled[0] == "1":
                 log.info("System is already booted with VTPM enabled")
@@ -262,6 +263,7 @@ class LparConfig():
                     return "Failed to boot with vtpm disabled"
 
         if "vpmem=1" in self.machine_config:
+            conf = OpTestConfiguration.conf
             try: self.pmem_name = conf.args.pmem_name
             except AttributeError:
                 self.pmem_name = "vol1"

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -126,7 +126,7 @@ class LparConfig():
         self.hmc_con = self.cv_HMC.ssh
         conf = OpTestConfiguration.conf
         self.cv_SYSTEM = conf.system()
-        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_HMC.poweroff_lpar()
         self.util = OpTestUtil(conf)
 
     def LparSetup(self):
@@ -276,6 +276,10 @@ class LparConfig():
                                if "=" in ioslot_drc_names else ioslot_drc_names
             self.cv_HMC.add_ioslot(ioslot_drc_names)
 
+        if "secureboot" in self.machine_config:
+            enable = self.util.validate_secureboot_parameter(self.machine_config)
+            self.cv_HMC.hmc_secureboot_on_off(enable)
+        
         self.cv_HMC.run_command("chsysstate -r lpar -m %s -o on -n %s -f %s" %
                                (self.system_name, self.lpar_name, self.lpar_prof))
         time.sleep(5)
@@ -285,14 +289,7 @@ class LparConfig():
                 log.info("System booted with %s mode" % proc_mode)
             else:
                 return "Failed to boot in %s mode" % proc_mode
-        
-        if "secureboot" in self.machine_config:
-            enable = self.util.validate_secureboot_parameter(self.machine_config)
-            hmc_secureboot = self.cv_HMC.hmc_secureboot_on_off(enable)
-            if hmc_secureboot:
-                log.info("Secureboot is successfully set to the desired state!")
-            else:
-                return "Failed to set secureboot to the desired state!" 
+
 
 class RestoreLAPRConfig(MachineConfig):
 


### PR DESCRIPTION
- Implemented config based APIs to enable / disable secureboot at the lpar-level & the os-level.
- Also added some related functions to cater the needs of the above two main APIs : os_secureboot_enable() hmc_secureboot_on_off() getPRePDisk() backup_restore_PRepDisk() check_secureboot_state()