### PR TITLE
Fix false positives with op-test kdump testcase

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -265,8 +265,19 @@ class PowerNVDump(unittest.TestCase):
                 self.c.run_command("ls /var/crash/%s/dump*" %
                                    self.crash_content[0])
             else:
-                self.c.run_command("ls /var/crash/%s/vmcore*" %
-                                   self.crash_content[0])
+                res = self.c.run_command("ls /var/crash/%s/vmcore*" %
+                                         self.crash_content[0])
+                paths = res[0].split()
+                file_names = [os.path.basename(path) for path in paths]
+                # Check if vmcore-dmesg-incomplete.txt is present in file_names
+                if "vmcore-dmesg-incomplete.txt" in file_names:
+                    raise OpTestError("kdump failed to create vmcore file")
+                else:
+                    filtered_files = [f for f in file_names if f.startswith("vmcore") and not f == "vmcore-dmesg.txt"]
+                    if filtered_files:
+                        log.debug("vmcore file  %s exists in crash dir" % filtered_files)
+                    else:
+                        raise OpTestError("kdump failed to create vmcore file")
             if boot_type == BootType.MPIPL:
                 self.c.run_command("ls /var/crash/%s/opalcore*" %
                                    self.crash_content[0])


### PR DESCRIPTION
Existing check for vmcore file was done based on wildcard search on string pattern vmcore*. In case of failure,  kdump creates "vmcore-dmesg-incomplete.txt" file in crash directory. In case of failure, that logic wrongly picks this file as vmcore file and tests pass though vmcore not generated. This fix checks  "vmcore-dmesg-incomplete.txt" file. If that file exists, then testcase fails with OpTestError. Otherwise , in successful case , there is check for  vmcore file, that should be one of these formats (vmcore, vmcore.flat, vmcore.1, vmcore.2 ....etc). If the vmcore file doesn't exist , then testcase fails with OpTestError.

The  vmcore file is saved under /var/crash/ip-date/vmcore


CASE 1 : when vmcore dump collection was successful  , file name formats could be shown as below          
RHEL/SLES                vmcore  (generic or default)
                         vmcore.1 vmcore.2...so on  (--split option is used for makedumpfile)
                         vmcore.flat  (SSH dump targets,  -F option is passed to makedumpfile)

Example:

[root@ltcever7x0-lp4 127.0.0.1-2023-08-10-00:54:48]# ls
kexec-dmesg.log  
vmcore  
vmcore-dmesg.txt
[root@ltcever7x0-lp4 127.0.0.1-2023-08-10-00:54:48]#

CASE 2 : when vmcore dump collection was failed, we can observe these behaviors 

RHEL/SLES : vmcore-dmesg-incomplete.txt 

Example :

[root@ltcever7x0-lp1 127.0.0.1-2023-08-14-10:17:44]# ls -1
vmcore-dmesg-incomplete.txt                                                                                                            
[root@ltcever7x0-lp1 127.0.0.1-2023-08-14-10:17:44]# 
