### PR TITLE
EBMC: Allow user to run bmc commands over ssh

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -922,9 +922,6 @@ class OpTestConfiguration():
                                     lpar_password=self.args.host_password,
                                     logfile=self.logfile
                                     )
-                else:
-                    raise Exception(
-                        "HMC IP, username and password is required")
                 rest_api = EBMCHostManagement(conf=self,
                                               ip=self.args.bmc_ip,
                                               username=self.args.bmc_username,
@@ -944,7 +941,16 @@ class OpTestConfiguration():
                     host=host,
                     conf=self,
                 )
-                hmc.set_system(self.op_system)
+                # For EBMC type of systems the implementation here is:
+                # By default the EBMC system will be phyp mode i.e the console object returns lpar console
+                # In case if someone wants to run bmc commands than the system is set to BMC mode i.e
+                # only BMC details (no hmc) have provided as input if user wants to run bmc commands over ssh
+                # so at any point of time the test can use either phyp or bmc mode, and not both
+                if hmc:
+                    hmc.set_system(self.op_system)
+                else:
+                    bmc.set_system(self.op_system)
+
             elif self.args.bmc_type in ['qemu']:
                 print((repr(self.args)))
                 bmc = OpTestQemu(conf=self,

--- a/common/OpTestEBMC.py
+++ b/common/OpTestEBMC.py
@@ -142,17 +142,17 @@ class OpTestEBMC():
         self.rest_api = rest_api
         self.has_vpnor = None
         self.logfile = logfile
-        if not self.hmc:
-            self.console = OpTestSSH(ip, username, password, port=2200,
-                                     logfile=self.logfile, check_ssh_keys=check_ssh_keys,
-                                     known_hosts_file=known_hosts_file)
 
-            self.bmc = OpTestBMC(ip=self.hostname,
-                                 username=self.username,
-                                 password=self.password,
-                                 logfile=self.logfile,
-                                 check_ssh_keys=check_ssh_keys,
+        self.console = OpTestSSH(ip, username, password, port=2200,
+                                 logfile=self.logfile, check_ssh_keys=check_ssh_keys,
                                  known_hosts_file=known_hosts_file)
+
+        self.bmc = OpTestBMC(ip=self.hostname,
+                             username=self.username,
+                             password=self.password,
+                             logfile=self.logfile,
+                             check_ssh_keys=check_ssh_keys,
+                             known_hosts_file=known_hosts_file)
 
     def set_system(self, system):
         self.console.set_system(system)


### PR DESCRIPTION
The previous patch restricted user to set system as phyp only, blocking it to run any bmc commands. so this fixes allowing to instantiate both phyp and bmc objects, and set system type based on the user config parameter given