### PR TITLE
Added support to configure the multiple lpars.

### DIFF
--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -245,7 +245,7 @@ class LparConfig():
                 self.overcommit_ratio = 1
             proc_mode = 'shared'
             curr_proc_mode = self.cv_HMC.get_proc_mode()
-            if proc_mode in curr_proc_mode and lpar_config == True:
+            if proc_mode in curr_proc_mode and not lpar_config:
                 log.info("System is already booted in shared mode.")
             else:
                 self.cv_HMC.profile_bckup()


### PR DESCRIPTION
This enhancement introduces support for configuring multiple lpars, such as lpar1, lpar2, and so on, especially when they are in shared mode.

To configure the multiple lpars user needs to pass below two parameters,
```
lpar_config=multi
lpar_list=lpar1, lpar2 ...etc
```
In this case, the user is required to explicitly specify these two parameters in the .conf file, and it's important to ensure that all lpars have unique passwords.