### PR TITLE
Moved testcase logic to use generic kernel path

### DIFF
--- a/testcases/GcovSetup.py
+++ b/testcases/GcovSetup.py
@@ -75,6 +75,8 @@ class GcovBuild(unittest.TestCase):
                 src_path = os.path.join(src_path, line)
                 break
         log.info("\n\nsource path = %s" %src_path)
+        self.cv_HOST.host_run_command('mv %s /root/kernel/linux' %src_path)
+        src_path = '/root/kernel/linux'
         log.info("\nadding gcov_param....")
         self.kernel_config(src_path)
         log.info("Building the new kernel...")

--- a/testcases/Lcov.py
+++ b/testcases/Lcov.py
@@ -53,7 +53,6 @@ class LcovSetup(unittest.TestCase):
         self.util = OpTestUtil(OpTestConfiguration.conf)
         self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
         self.distro = self.util.distro_name()
-        self.k_version = "".join(self.cv_HOST.host_run_command("uname -r"))
 
     def runTest(self):
         '''
@@ -102,8 +101,7 @@ class LcovGatherData(LcovSetup):
         Running the test
         '''
         self.c = self.cv_SYSTEM.cv_HOST.get_ssh_connection()
-        self.k_version = "".join(self.cv_HOST.host_run_command("uname -r"))
-        src_path = f'/root/kernel-{self.k_version}*/linux-{self.k_version}*'
+        src_path = f'/root/kernel/linux'
         self.cv_HOST.host_run_command(f"cd {src_path}")
         src_path = "".join(self.cv_HOST.host_run_command("pwd"))
         temp_dir = tempfile.mkdtemp(prefix="Lcov_result_")


### PR DESCRIPTION
Moved testcase logic to use generic kernel path which can help user to not have diffrent path