### PR TITLE
Fix IndexError: list index out of range issue

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -299,7 +299,10 @@ class HMCUtil():
         for values in list(splitter):
             data = values.split("=")
             key = data[0]
-            value = data[1]
+            try:
+                value = data[1]
+            except IndexError:
+                value = 'null'
             cfg_dict[key] = value
         return cfg_dict
 

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -439,7 +439,7 @@ class OsConfig():
         self.hmc_con = self.cv_HMC.ssh
         self.mmulist = self.c.run_command("tail /proc/cpuinfo | grep MMU")
         self.mmu = str(self.mmulist[0]).split(':')[1].strip()
-        self.cmdline = self.c.run_command("cat /proc/cmdline | grep -o disable_radix=1")
+        self.cmdline = self.c.run_command("cat /proc/cmdline")
         self.obj = OpTestInstallUtil.InstallUtil()
         self.os_level = self.cv_HOST.host_get_OS_Level()
         self.size_hgpg = hugepage


### PR DESCRIPTION
In case of any LAPR key does not have value op-test error out as

ERROR: runTest (testcases.HelloWorld.HelloWorld)
---------------------------------------------------------------------- Traceback (most recent call last):
  File "/home/op-test/testcases/HelloWorld.py", line 44, in runTest
    exist_cfg = self.cv_HMC.get_lpar_cfg()
  File "/home/op-test/common/OpTestHMC.py", line 309, in get_lpar_cfg
    value = data[1]
IndexError: list index out of range

as this fix populate that value as null string