### PR TITLE
Added support to configure the multiple lpars-v2

### DIFF
--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -33,7 +33,6 @@ import json
 
 import OpTestConfiguration
 import OpTestLogger
-from common import OpTestHMC
 from common import OpTestInstallUtil
 from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
@@ -57,11 +56,6 @@ class MachineConfig(unittest.TestCase):
             self.system_name = conf.args.system_name
             self.cv_HMC = self.cv_SYSTEM.hmc
             self.lpar_prof = conf.args.lpar_prof
-            self.lpar_flag = False
-            try:
-                self.lpar_list = conf.args.lpar_list
-            except AttributeError:
-                self.lpar_list = ""
             self.util = OpTestUtil(conf)
         else:
             self.skipTest("Functionality is supported only on LPAR")
@@ -85,41 +79,12 @@ class MachineConfig(unittest.TestCase):
         else:
             return False
 
-    def update_hmc_object(self, target_hmc_ip, target_hmc_username, target_hmc_password,
-                          managed_system, lpar_name):
-        """
-        In case of multi lpar configuration here we are creating multiple objects[In sequence] as per 
-        lpar change.
-        """
-        conf = OpTestConfiguration.conf
-        self.cv_HMC = OpTestHMC.OpTestHMC(target_hmc_ip,
-                                          target_hmc_username,
-                                          target_hmc_password,
-                                          managed_system=managed_system,
-                                          lpar_name=lpar_name,
-                                          lpar_prof=conf.args.lpar_prof
-                                          )
-        self.cv_HMC.set_system(conf.system())
-
     def runTest(self):
-        if self.lpar_list != "":
-            self.lpar_list = self.lpar_list.split(",")
-            self.lpar_list.append(self.lpar_name)
-            self.lpar_flag = True
-            for lpar in self.lpar_list:
-                lpar = lpar.strip()
-                self.update_hmc_object(
-                    self.hmc_ip, self.hmc_user, self.hmc_password, self.system_name, lpar)
-                for key in self.machine_config:
-                    self.callConfig(key, lpar)
-        else:
-            for key in self.machine_config:
-                self.callConfig(key)
 
-    def callConfig(self, key, lpar=""):
+        for key in self.machine_config:
+            self.callConfig(key)
 
-        if lpar != "":
-            self.lpar_name = lpar
+    def callConfig(self, key):
 
         status = 0
         if key == "lpar":
@@ -129,7 +94,7 @@ class MachineConfig(unittest.TestCase):
                 self.sb_enable = self.validate_secureboot_parameter(
                     self.machine_config)
             status = LparConfig(self.cv_HMC, self.system_name, self.lpar_name, self.lpar_prof,
-                                self.machine_config['lpar'], sb_enable=self.sb_enable).LparSetup(self.lpar_flag)
+                                self.machine_config['lpar'], sb_enable=self.sb_enable).LparSetup()
             if status:
                 self.fail(status)
 
@@ -209,7 +174,7 @@ class LparConfig():
         self.util = OpTestUtil(conf)
         self.sb_enable = sb_enable
 
-    def LparSetup(self, lpar_config=""):
+    def LparSetup(self):
         '''
         If cpu=shared is passed in machine_config lpar proc mode changes to shared mode.
         Pass sharing_mode, min_proc_units, max_proc_units and desired_proc_units in config file.
@@ -245,11 +210,10 @@ class LparConfig():
                 self.overcommit_ratio = 1
             proc_mode = 'shared'
             curr_proc_mode = self.cv_HMC.get_proc_mode()
-            if proc_mode in curr_proc_mode and not lpar_config:
+            if proc_mode in curr_proc_mode:
                 log.info("System is already booted in shared mode.")
             else:
-                if not lpar_config:
-                    self.cv_HMC.profile_bckup()
+                self.cv_HMC.profile_bckup()
                 self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
                                              self.desired_proc_units, self.max_proc_units, self.overcommit_ratio)
 
@@ -550,7 +514,7 @@ class OsConfig():
                 self.no_hgpg = int(self.percentile / 16)
             self.obj.update_kernel_cmdline(self.os_level,
                                            "default_hugepagesz=%s hugepagesz=%s hugepages=%s" % (
-                                           self.size_hgpg, self.size_hgpg, self.no_hgpg),
+                                               self.size_hgpg, self.size_hgpg, self.no_hgpg),
                                            "",
                                            reboot=True,
                                            reboot_cmd=True)

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -33,11 +33,13 @@ import json
 
 import OpTestConfiguration
 import OpTestLogger
+from common import OpTestHMC
 from common import OpTestInstallUtil
 from common.OpTestUtil import OpTestUtil
 from common.OpTestSystem import OpSystemState
 
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
 
 class MachineConfig(unittest.TestCase):
 
@@ -47,7 +49,7 @@ class MachineConfig(unittest.TestCase):
         self.cv_SYSTEM = conf.system()
         self.bmc_type = conf.args.bmc_type
         self.machine_config = json.loads(conf.args.machine_config)
-        if self.bmc_type == "FSP_PHYP" or self.bmc_type == "EBMC_PHYP" :
+        if self.bmc_type == "FSP_PHYP" or self.bmc_type == "EBMC_PHYP":
             self.hmc_user = conf.args.hmc_username
             self.hmc_password = conf.args.hmc_password
             self.hmc_ip = conf.args.hmc_ip
@@ -55,6 +57,11 @@ class MachineConfig(unittest.TestCase):
             self.system_name = conf.args.system_name
             self.cv_HMC = self.cv_SYSTEM.hmc
             self.lpar_prof = conf.args.lpar_prof
+            self.lpar_flag = False
+            try:
+                self.lpar_list = conf.args.lpar_list
+            except AttributeError:
+                self.lpar_list = ""
             self.util = OpTestUtil(conf)
         else:
             self.skipTest("Functionality is supported only on LPAR")
@@ -68,7 +75,8 @@ class MachineConfig(unittest.TestCase):
         False - if secureboot is set to 'off'
         '''
         sb_valid_states = ['on', 'off']
-        secureboot_parameter_state = re.findall("secureboot=[a-z][a-z]+", str(machine_config))[0].split('=')[1]
+        secureboot_parameter_state = re.findall(
+            "secureboot=[a-z][a-z]+", str(machine_config))[0].split('=')[1]
         if str(secureboot_parameter_state) not in sb_valid_states:
             self.skipTest("%s is not a valid state for secureboot. "
                           "Secureboot valid states can be either set to 'on' or 'off'" % str(secureboot_parameter_state))
@@ -77,44 +85,76 @@ class MachineConfig(unittest.TestCase):
         else:
             return False
 
+    def update_hmc_object(self, target_hmc_ip, target_hmc_username, target_hmc_password,
+                          managed_system, lpar_name):
+        """
+        In case of multi lpar configuration here we are creating multiple objects[In sequence] as per 
+        lpar change.
+        """
+        conf = OpTestConfiguration.conf
+        self.cv_HMC = OpTestHMC.OpTestHMC(target_hmc_ip,
+                                          target_hmc_username,
+                                          target_hmc_password,
+                                          managed_system=managed_system,
+                                          lpar_name=lpar_name,
+                                          lpar_prof=conf.args.lpar_prof
+                                          )
+        self.cv_HMC.set_system(conf.system())
 
     def runTest(self):
-        
-        for key in self.machine_config:
-            self.callConfig(key)
+        if self.lpar_list != "":
+            self.lpar_list = self.lpar_list.split(",")
+            self.lpar_list.append(self.lpar_name)
+            self.lpar_flag = True
+            for lpar in self.lpar_list:
+                lpar = lpar.strip()
+                self.update_hmc_object(
+                    self.hmc_ip, self.hmc_user, self.hmc_password, self.system_name, lpar)
+                for key in self.machine_config:
+                    self.callConfig(key, lpar)
+        else:
+            for key in self.machine_config:
+                self.callConfig(key)
 
-    def callConfig(self, key):
-    
-        status=0
+    def callConfig(self, key, lpar=""):
+
+        if lpar != "":
+            self.lpar_name = lpar
+
+        status = 0
         if key == "lpar":
             self.sb_enable = None
-            config_value=self.machine_config['lpar']
+            config_value = self.machine_config['lpar']
             if 'secureboot' in config_value:
-                self.sb_enable = self.validate_secureboot_parameter(self.machine_config)
-            status=LparConfig(self.cv_HMC,self.system_name,self.lpar_name,self.lpar_prof,self.machine_config['lpar'],sb_enable=self.sb_enable).LparSetup()
+                self.sb_enable = self.validate_secureboot_parameter(
+                    self.machine_config)
+            status = LparConfig(self.cv_HMC, self.system_name, self.lpar_name, self.lpar_prof,
+                                self.machine_config['lpar'], sb_enable=self.sb_enable).LparSetup(self.lpar_flag)
             if status:
                 self.fail(status)
 
         if key == "cec":
-            lmb_size= None
+            lmb_size = None
             num_hugepages = None
             setup = 0
             if not self.cv_HMC.lpar_vios:
                 self.skipTest("Please pass lpar_vios in config file.")
-            config_value=self.machine_config['cec']
+            config_value = self.machine_config['cec']
             valid_size = [128, 256, 1024, 2048, 4096]
             if "lmb" in config_value:
                 setup = 1
-                lmb_size = re.findall('lmb=[0-9]+', str(self.machine_config))[0].split('=')[1]
+                lmb_size = re.findall(
+                    'lmb=[0-9]+', str(self.machine_config))[0].split('=')[1]
                 if int(lmb_size) not in valid_size:
                     self.skipTest("%s is not valid lmb size, "
                                   "valid lmb sizes are 128, 256, 1024, 2048, 4096" % lmb_size)
             if "hugepages" in config_value:
                 setup = 1
                 num_hugepages = re.findall(
-                        'hugepages=[0-9]+', str(self.machine_config))[0].split('=')[1]
+                    'hugepages=[0-9]+', str(self.machine_config))[0].split('=')[1]
 
-            status = CecConfig(self.cv_HMC,self.system_name,self.lpar_name,self.lpar_prof,lmb=lmb_size,hugepages=num_hugepages).CecSetup()
+            status = CecConfig(self.cv_HMC, self.system_name, self.lpar_name,
+                               self.lpar_prof, lmb=lmb_size, hugepages=num_hugepages).CecSetup()
             if status:
                 self.fail(status)
             if not setup:
@@ -135,8 +175,10 @@ class MachineConfig(unittest.TestCase):
                                   "valid hugepage sizes are 1G, 2M, 16M, 16G" % hugepage_size)
             if 'secureboot' in config_value:
                 setup = 1
-                sb_enable = self.validate_secureboot_parameter(self.machine_config)
-            status = OsConfig(self.cv_HMC, self.system_name, self.lpar_name, self.lpar_prof, self.machine_config['os'],enable=sb_enable, hugepage=hugepage_size).Ossetup()
+                sb_enable = self.validate_secureboot_parameter(
+                    self.machine_config)
+            status = OsConfig(self.cv_HMC, self.system_name, self.lpar_name, self.lpar_prof,
+                              self.machine_config['os'], enable=sb_enable, hugepage=hugepage_size).Ossetup()
             if status:
                 self.fail(status)
             if not setup:
@@ -152,13 +194,14 @@ class LparConfig():
                   vpmem=0 or vpmem=1
     Ex: machine_config="cpu=dedicated,vtpm=1,vpmem=1"
     '''
-    def __init__(self, cv_HMC=None, system_name= None,
-                 lpar_name=None, lpar_prof=None, machin_config =None, sb_enable=None):
+
+    def __init__(self, cv_HMC=None, system_name=None,
+                 lpar_name=None, lpar_prof=None, machin_config=None, sb_enable=None):
         self.cv_HMC = cv_HMC
         self.system_name = system_name
         self.lpar_name = lpar_name
         self.lpar_prof = lpar_prof
-        self.machine_config=machin_config
+        self.machine_config = machin_config
         self.hmc_con = self.cv_HMC.ssh
         conf = OpTestConfiguration.conf
         self.cv_SYSTEM = conf.system()
@@ -166,7 +209,7 @@ class LparConfig():
         self.util = OpTestUtil(conf)
         self.sb_enable = sb_enable
 
-    def LparSetup(self):
+    def LparSetup(self, lpar_config=""):
         '''
         If cpu=shared is passed in machine_config lpar proc mode changes to shared mode.
         Pass sharing_mode, min_proc_units, max_proc_units and desired_proc_units in config file.
@@ -180,27 +223,33 @@ class LparConfig():
         proc_mode = None
         if "cpu=shared" in self.machine_config:
             conf = OpTestConfiguration.conf
-            try: self.sharing_mode = conf.args.sharing_mode
+            try:
+                self.sharing_mode = conf.args.sharing_mode
             except AttributeError:
                 self.sharing_mode = "cap"
-            try: self.min_proc_units = float(conf.args.min_proc_units)
+            try:
+                self.min_proc_units = float(conf.args.min_proc_units)
             except AttributeError:
                 self.min_proc_units = 1.0
-            try: self.desired_proc_units = float(conf.args.desired_proc_units)
+            try:
+                self.desired_proc_units = float(conf.args.desired_proc_units)
             except AttributeError:
                 self.desired_proc_units = 2.0
-            try: self.max_proc_units = float(conf.args.max_proc_units)
+            try:
+                self.max_proc_units = float(conf.args.max_proc_units)
             except AttributeError:
                 self.max_proc_units = 2.0
-            try: self.overcommit_ratio = int(conf.args.overcommit_ratio)
+            try:
+                self.overcommit_ratio = int(conf.args.overcommit_ratio)
             except AttributeError:
                 self.overcommit_ratio = 1
             proc_mode = 'shared'
             curr_proc_mode = self.cv_HMC.get_proc_mode()
-            if proc_mode in curr_proc_mode:
+            if proc_mode in curr_proc_mode and not lpar_config:
                 log.info("System is already booted in shared mode.")
             else:
-                self.cv_HMC.profile_bckup()
+                if not lpar_config:
+                    self.cv_HMC.profile_bckup()
                 self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
                                              self.desired_proc_units, self.max_proc_units, self.overcommit_ratio)
 
@@ -216,16 +265,20 @@ class LparConfig():
 
         if "cpu=dedicated" in self.machine_config:
             conf = OpTestConfiguration.conf
-            try: self.sharing_mode = conf.args.sharing_mode
+            try:
+                self.sharing_mode = conf.args.sharing_mode
             except AttributeError:
                 self.sharing_mode = "share_idle_procs"
-            try: self.min_proc_units = conf.args.min_proc_units
+            try:
+                self.min_proc_units = conf.args.min_proc_units
             except AttributeError:
                 self.min_proc_units = "1"
-            try: self.desired_proc_units = conf.args.desired_proc_units
+            try:
+                self.desired_proc_units = conf.args.desired_proc_units
             except AttributeError:
                 self.desired_proc_units = "2"
-            try: self.max_proc_units = conf.args.max_proc_units
+            try:
+                self.max_proc_units = conf.args.max_proc_units
             except AttributeError:
                 self.max_proc_units = "2"
             proc_mode = 'ded'
@@ -237,7 +290,6 @@ class LparConfig():
                 self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
                                              self.desired_proc_units, self.max_proc_units)
 
-
         if "vtpm=1" in self.machine_config:
             conf = OpTestConfiguration.conf
             vtpm_enabled = self.cv_HMC.vtpm_state()
@@ -247,14 +299,16 @@ class LparConfig():
                 proc_compat_mode = self.cv_HMC.get_proc_compat_mode()
                 if "POWER10" in proc_compat_mode:
                     self.vtpm_version = 2.0
-                    try: self.vtpm_encryption = conf.args.vtpm_encryption
+                    try:
+                        self.vtpm_encryption = conf.args.vtpm_encryption
                     except AttributeError:
                         self.vtpm_encryption = "Power10v1"
                 elif proc_compat_mode[0] in ["POWER9_base", "POWER9", "POWER8"]:
                     self.vtpm_version = 1.2
                 else:
                     log.info("Unknown processor compact mode")
-                self.cv_HMC.enable_vtpm(self.vtpm_version, self.vtpm_encryption)
+                self.cv_HMC.enable_vtpm(
+                    self.vtpm_version, self.vtpm_encryption)
                 vtpm_enabled = self.cv_HMC.vtpm_state()
                 if vtpm_enabled[0] == "1":
                     log.info("System booted with VTPM enabled")
@@ -276,13 +330,15 @@ class LparConfig():
 
         if "vpmem=1" in self.machine_config:
             conf = OpTestConfiguration.conf
-            try: self.pmem_name = conf.args.pmem_name
+            try:
+                self.pmem_name = conf.args.pmem_name
             except AttributeError:
                 self.pmem_name = "vol1"
-            try: self.pmem_size = conf.args.pmem_size
+            try:
+                self.pmem_size = conf.args.pmem_size
             except AttributeError:
                 self.pmem_size = "8192"
-            if self.cv_HMC.vpmem_count() [0] >= "1":
+            if self.cv_HMC.vpmem_count()[0] >= "1":
                 self.cv_HMC.remove_vpmem()
             current_lmb = self.cv_HMC.get_lmb_size()
             if int(self.pmem_size) % int(current_lmb[0]) != 0:
@@ -290,13 +346,15 @@ class LparConfig():
             self.cv_HMC.configure_vpmem(self.pmem_name, self.pmem_size)
             curr_num_volumes = self.cv_HMC.vpmem_count()
             if curr_num_volumes[0] >= "1":
-                log.info("Configured vpmem %s of %sMB" % (self.pmem_name, self.pmem_size))
+                log.info("Configured vpmem %s of %sMB" %
+                         (self.pmem_name, self.pmem_size))
             else:
                 return "Failed to configure pmem"
 
         if "nx_gzip" in self.machine_config:
             conf = OpTestConfiguration.conf
-            try: self.qos_credits =  round(float(conf.args.qos_credits))
+            try:
+                self.qos_credits = round(float(conf.args.qos_credits))
             except AttributeError:
                 self.qos_credits = 10
             proc_compat_mode = self.cv_HMC.get_proc_compat_mode()
@@ -310,16 +368,17 @@ class LparConfig():
         """
 
         if "slot=" in self.machine_config:
-            ioslot_drc_names = "".join(self.machine_config[self.machine_config.index("slot=")+len("slot=")+1:])
+            ioslot_drc_names = "".join(
+                self.machine_config[self.machine_config.index("slot=")+len("slot=")+1:])
             ioslot_drc_names = ",".join(ioslot_drc_names[:ioslot_drc_names.index("=")].split(",")[:-1]) \
                                if "=" in ioslot_drc_names else ioslot_drc_names
             self.cv_HMC.add_ioslot(ioslot_drc_names)
 
-        if self.sb_enable is not None :
+        if self.sb_enable is not None:
             self.cv_HMC.hmc_secureboot_on_off(self.sb_enable)
-        
+
         self.cv_HMC.run_command("chsysstate -r lpar -m %s -o on -n %s -f %s" %
-                               (self.system_name, self.lpar_name, self.lpar_prof))
+                                (self.system_name, self.lpar_name, self.lpar_prof))
         time.sleep(5)
         curr_proc_mode = self.cv_HMC.get_proc_mode()
         if proc_mode:
@@ -344,6 +403,7 @@ class RestoreLAPRConfig(MachineConfig):
         self.cv_HMC.lpar_prof = self.cv_HMC.lpar_prof + "_bck"
         self.cv_HMC.poweron_lpar()
 
+
 class CecConfig():
 
     '''
@@ -355,7 +415,8 @@ class CecConfig():
     in config file
     Ex: machine_config={"cec":"hugepages=4"}
     '''
-    def __init__(self, cv_HMC=None, system_name= None,
+
+    def __init__(self, cv_HMC=None, system_name=None,
                  lpar_name=None, lpar_prof=None, lmb=None, hugepages=None):
 
         self.cv_HMC = cv_HMC
@@ -379,7 +440,7 @@ class CecConfig():
         if self.setup:
             self.cv_HMC.poweron_system()
             self.ValidateCEC_Setup()
-            ##loading system
+            # loading system
             self.cv_HMC.run_command("chsysstate -r lpar -m %s -o on -n %s -f %s" %
                                     (self.system_name, self.lpar_name, self.lpar_prof))
             time.sleep(5)
@@ -395,27 +456,29 @@ class CecConfig():
         if self.num_hugepages:
             self.current_hgpg = self.cv_HMC.get_16gb_hugepage_size()
             if int(self.current_hgpg[0]) != 0:
-                log.info("System configured with %s 16gb Hugepage" % self.current_hgpg[0])
+                log.info("System configured with %s 16gb Hugepage" %
+                         self.current_hgpg[0])
                 self.cv_HMC.poweroff_lpar()
                 self.setting_16gb_hugepage_profile()
             else:
                 self.cec_dict['hugepages'] = self.num_hugepages
 
     def lmb_setup(self):
-        #Configure the lmb as per user request
+        # Configure the lmb as per user request
         self.cv_HMC.configure_lmb(self.lmb_size)
-        self.setup =1
+        self.setup = 1
 
     def hugepage_16gb_setup(self):
-        #configure the number of 16gb hugepages as per user request
+        # configure the number of 16gb hugepages as per user request
         self.cv_HMC.configure_16gb_hugepage(self.num_hugepages)
         self.setup = 1
 
     def setting_16gb_hugepage_profile(self):
         self.current_hgpg = self.cv_HMC.get_16gb_hugepage_size()
         attrs = "min_num_huge_pages={0},desired_num_huge_pages={0},max_num_huge_pages={0}" .format(
-           int(self.current_hgpg[0]))
+            int(self.current_hgpg[0]))
         self.cv_HMC.set_lpar_cfg(attrs)
+
 
 class OsConfig():
     '''
@@ -480,7 +543,7 @@ class OsConfig():
                     self.fail("16M is not supported in Radix")
                 elif self.size_hgpg == "2M":
                     self.no_hgpg = int(self.percentile / 2)
-                elif  self.size_hgpg == "1G":
+                elif self.size_hgpg == "1G":
                     self.no_hgpg = int(self.percentile / 1024)
 
             elif 'Hash' in self.mmu and self.size_hgpg == "16M":
@@ -506,7 +569,6 @@ class OsConfig():
             return msg
         else:
             log.info("%s Hugepage validation successful!" % self.size_hgpg)
-
 
     def configure_os_16gb_hugepage(self):
         if 'Radix' in self.mmu:


### PR DESCRIPTION
This enhancement introduces support for configuring multiple lpars, such as lpar1, lpar2, and so on, especially when they are in shared mode.

To configure the multiple lpars user need to pass below two parameters, lpar_config=multi
lpar_lis=lpar1, lpar2 ...etc
In this case, users are required to explicitly specify these two parameters in the .conf file, and it's important to ensure that all lpars have unique passwords.