### PR TITLE
MachineConfig.py: Add support for max procs to available procs of CEC

### DIFF
--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -318,9 +318,7 @@ class LparConfig():
         if self.sb_enable is not None :
             self.cv_HMC.hmc_secureboot_on_off(self.sb_enable)
         
-        self.cv_HMC.run_command("chsysstate -r lpar -m %s -o on -n %s -f %s" %
-                               (self.system_name, self.lpar_name, self.lpar_prof))
-        time.sleep(5)
+        self.cv_HMC.poweron_lpar()
         curr_proc_mode = self.cv_HMC.get_proc_mode()
         if proc_mode:
             if proc_mode in curr_proc_mode:

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -227,7 +227,7 @@ class LparConfig():
                 self.desired_proc_units = "2"
             try: self.max_proc_units = conf.args.max_proc_units
             except AttributeError:
-                self.max_proc_units = "2"
+                self.max_proc_units = int(float(self.cv_HMC.get_available_proc_resources()[0]))
             proc_mode = 'ded'
             curr_proc_mode = self.cv_HMC.get_proc_mode()
             if proc_mode in curr_proc_mode:


### PR DESCRIPTION
Added support which boots the lpar into dedicated mode by setting the max procs to the available procs of CEC