### PR TITLE
Enable op-test to be used from anywhere

### DIFF
--- a/OpTestConfiguration.py
+++ b/OpTestConfiguration.py
@@ -472,7 +472,7 @@ class OpTestConfiguration():
         self.cronus = OpTestCronus(self)
         self.args = []
         self.remaining_args = []
-        self.basedir = os.path.dirname(sys.argv[0])
+        self.basedir = os.path.abspath(os.path.dirname(__file__))
         self.signal_ready = False  # indicator for properly initialized
         self.atexit_ready = False  # indicator for properly initialized
         self.aes_print_helpers = True  # Need state for locker_wait

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ After cloning FWTS see the README for pre-reqs and how-to,
 be sure to 'make install' after building to get the proper
 paths setup.
 
-git clone git://kernel.ubuntu.com/hwe/fwts.git
+git clone https://github.com/fwts/fwts
 
 It must also have (package names for Debian/Ubuntu systems):
 


### PR DESCRIPTION
This PR contains two minor changes:

1. feat: allow op-test usage from anywhere

   Currently, if a symlink to 'op-test' is created somewhere (such as in
   /usr/local/bin/), it fails to start with following error:

   ```
   $ cd /usr/local/bin
   $ ln -sv PATH_TO_op-test/op-test
   $
   $ op-test --help

   Traceback (most recent call last):
     File "/tmp/./op-test2", line 125, in <module>
       OpTestConfiguration.conf = OpTestConfiguration.OpTestConfiguration()
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/tmp/op-test/OpTestConfiguration.py", line 492, in __init__
       for dirname in (next(os.walk(os.path.join(self.basedir, 'addons')))[1]):
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   StopIteration
   ```

   This is because, `self.basedir` is pointing to the current working
   directory or path of the symlink (sys.argv[0]), and it didn't find
   self.basedir/'addons' folder.

   Solve this by ensuring `self.basedir` points to the directory containing
   the op-test script.

   This enables us to install op-test symlink in somewhere like
   `/usr/local/bin`, and thus being able to run it from anywhere.

2. readme: update fwts link to point to github repository

    Older link `git://kernel.ubuntu.com/hwe/fwts.git` is not working
    anymore, and even ubuntu's official wiki about FirmwareTestSuite now
    gives the source link pointing to github.com/fwts/fwts.

    Replace the fwts github repository link to github.com link

Thanks,
Aditya Gupta

