### PR TITLE
MachineConfig.py:Add support for max memory to available memory of CEC

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -398,7 +398,8 @@ class HMCUtil():
         drc_index_out = [line for line in drc_index_out if ioslot+":" in line]
         return drc_index_out[0].split(":")[0] if drc_index_out is not None else None
 
-    def change_proc_mode(self, proc_mode, sharing_mode, min_proc_units, desired_proc_units, max_proc_units, overcommit_ratio=1):
+    def change_proc_mode(self, proc_mode, sharing_mode, min_proc_units, desired_proc_units, max_proc_units,
+                          min_memory, desired_memory, max_memory, overcommit_ratio=1):
         '''
         Sets processor mode to shared or dedicated based on proc_mode
 
@@ -416,8 +417,10 @@ class HMCUtil():
                                overcommit_ratio*int(min_proc_units), overcommit_ratio*int(desired_proc_units),
                                overcommit_ratio*int(max_proc_units)))
         elif proc_mode == 'ded':
-            self.set_lpar_cfg("proc_mode=ded,sharing_mode=%s,min_procs=%s,max_procs=%s,desired_procs=%s" %
-                             (sharing_mode, min_proc_units, max_proc_units, desired_proc_units))
+            self.set_lpar_cfg("proc_mode=ded,sharing_mode=%s,min_procs=%s,max_procs=%s,desired_procs=%s,"
+                              "min_mem=%s,desired_mem=%s,max_mem=%s" %
+                              (sharing_mode, min_proc_units, max_proc_units, desired_proc_units,
+                               min_memory, desired_memory, max_memory))
         else:
             log.info("Please pass valid proc_mode, \"shared\" or \"ded\"")
 

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -196,14 +196,9 @@ class LparConfig():
             except AttributeError:
                 self.overcommit_ratio = 1
             proc_mode = 'shared'
-            curr_proc_mode = self.cv_HMC.get_proc_mode()
-            if proc_mode in curr_proc_mode:
-                log.info("System is already booted in shared mode.")
-            else:
-                self.cv_HMC.profile_bckup()
-                self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
-                                             self.desired_proc_units, self.max_proc_units, self.overcommit_ratio)
-
+            self.cv_HMC.profile_bckup()
+            self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
+                                         self.desired_proc_units, self.max_proc_units, self.overcommit_ratio)
         '''
         If cpu=dedicated is passed in machine_config lpar proc mode changes to dedicated mode.
         Pass sharing_mode, min_proc_units, max_proc_units and desired_proc_units in config file.
@@ -238,13 +233,10 @@ class LparConfig():
             except AttributeError:
                 self.max_memory = self.cv_HMC.get_available_mem_resources()[0]
             proc_mode = 'ded'
-            curr_proc_mode = self.cv_HMC.get_proc_mode()
-            if proc_mode in curr_proc_mode:
-                log.info("System is already booted in dedicated mode.")
-            else:
-                self.cv_HMC.profile_bckup()
-                self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
-                                             self.desired_proc_units, self.max_proc_units)
+            self.cv_HMC.profile_bckup()
+            self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
+                                         self.desired_proc_units, self.max_proc_units,
+                                         self.min_memory, self.desired_memory, self.max_memory)
 
         if "vtpm=1" in self.machine_config:
             conf = OpTestConfiguration.conf

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -228,6 +228,15 @@ class LparConfig():
             try: self.max_proc_units = conf.args.max_proc_units
             except AttributeError:
                 self.max_proc_units = int(float(self.cv_HMC.get_available_proc_resources()[0]))
+            try: self.min_memory = conf.args.min_memory
+            except AttributeError:
+                self.min_memory = "4096"
+            try: self.desired_memory = conf.args.desired_memory
+            except AttributeError:
+                self.desired_memory = "40960"
+            try: self.max_memory = conf.args.max_memory
+            except AttributeError:
+                self.max_memory = self.cv_HMC.get_available_mem_resources()[0]
             proc_mode = 'ded'
             curr_proc_mode = self.cv_HMC.get_proc_mode()
             if proc_mode in curr_proc_mode:
@@ -236,7 +245,6 @@ class LparConfig():
                 self.cv_HMC.profile_bckup()
                 self.cv_HMC.change_proc_mode(proc_mode, self.sharing_mode, self.min_proc_units,
                                              self.desired_proc_units, self.max_proc_units)
-
 
         if "vtpm=1" in self.machine_config:
             conf = OpTestConfiguration.conf


### PR DESCRIPTION
1.Added support which boots the lpar into dedicated mode by setting the max memory to the available memory of CEC. 2.common/OpTestHMC.py:Added memory part to change_proc_mode function