### PR TITLE
Fix console hang issue after setting fadump_registered value

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -295,6 +295,7 @@ class PowerNVDump(unittest.TestCase):
             return True 
         else:
             self.c.run_command("echo 1 > /sys/kernel/fadump_registered")
+            self.c.run_command('\r\n')
             self.c.run_command("cat /sys/kernel/fadump_registered")
 
         if not self.is_lpar:
@@ -330,11 +331,13 @@ class PowerNVDump(unittest.TestCase):
             return True 
         else:
             self.c.run_command("echo 0 > /sys/kernel/fadump_registered")
+            self.c.run_command('\r\n')
 
         if not self.is_lpar:
             self.c.run_command("%s > /tmp/opal_log" % BMC_CONST.OPAL_MSG_LOG)
             self.c.run_command("dmesg > /tmp/dmesg_log")
             self.c.run_command("echo 0 > /sys/kernel/fadump_registered")
+            self.c.run_command('\r\n')
 
             opal_data = " ".join(self.c.run_command(
                 "%s | diff -a /tmp/opal_log -" % BMC_CONST.OPAL_MSG_LOG))


### PR DESCRIPTION
Fadump  tests in op-test framework  frequently timed-out due to console issue , after  we run the command "echo 1 (or 0) >/sys/kernel/fadump_registered" from console. This was needed for op-test framework where we run commands on remote machine. After the execution of this command , it does not return the prompt( Instead it hangs/time out) . It needs another manual enter key to get console prompt. So , fix was to send newline after setting fadump_registered
