### PR TITLE
Split kdump and fadump test suites to run separately

### DIFF
--- a/op-test
+++ b/op-test
@@ -668,6 +668,43 @@ class OSdumpSuite():
     def suite(self):
         return self.s
 
+class OSdumpkdumpSuite():
+    '''Crash Test Suite which Verify operating System Crash Dump Functionality'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(PowerNVDump.KernelCrash_OnlyKdumpEnable())
+        if 'dev_path' in OpTestConfiguration.conf.args:
+            self.s.addTest(PowerNVDump.KernelCrash_KdumpSAN())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpDLPAR())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpWorkLoad())
+        self.s.addTest(PowerNVDump.KernelCrash_hugepage_checks())
+        self.s.addTest(PowerNVDump.KernelCrash_XIVE_off())
+        self.s.addTest(PowerNVDump.KernelCrash_disable_radix())
+        self.s.addTest(PowerNVDump.OpTestMakedump())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpSSH())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpNFS())
+
+    def suite(self):
+        return self.s
+
+class OSdumpfadumpSuite():
+    '''Crash Test Suite which Verify operating System Crash Dump Functionality'''
+    def __init__(self):
+        self.s = unittest.TestSuite()
+        self.s.addTest(PowerNVDump.KernelCrash_FadumpEnable())
+        self.s.addTest(PowerNVDump.OpTestMakedump())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpDLPAR())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpWorkLoad())
+        self.s.addTest(PowerNVDump.KernelCrash_hugepage_checks())
+        self.s.addTest(PowerNVDump.KernelCrash_XIVE_off())
+        self.s.addTest(PowerNVDump.KernelCrash_disable_radix())
+        self.s.addTest(PowerNVDump.KernelCrash_FadumpNocma())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpSSH())
+        self.s.addTest(PowerNVDump.KernelCrash_KdumpNFS())
+
+    def suite(self):
+        return self.s
+
 class OSdumpsanitySuite():
     '''Test Suite which runs kdump and fadump basic sanity tests'''
     def __init__(self):
@@ -942,6 +979,8 @@ suites = {
     'opencapi': OpenCAPISuite(),
     'crash-suite': CrashSuite(),
     'osdump-suite': OSdumpSuite(),
+    'osdumpkdumpsuite': OSdumpkdumpSuite(),
+    'osdumpfadumpsuite': OSdumpfadumpSuite(),
     'osdumpsanitysuite': OSdumpsanitySuite(),
     'dlpario-suite': DlparIOSuite(),
     'lpm-suite': LPMSuite(),


### PR DESCRIPTION
The existing `OSdumpSuite()`  can be split into two separate test suites for kdump and fadump for following reasons :

1) When there was failure in kdump testcase , it blocked fadump tests completely. This way, fadump test execution will not be interrupted by kdump test failure.

2) There was mix of local and remote dump collection test cases between test flow. So , with this change , execute all local dump related tests together (at the beginning) . Later run the remote dump target tests . This will avoid extra effort in fixing the test configuration (/etc/kdump.conf  or /etc/sysconfig/kdump)  changes,  when switching from local to remote dump targets (vice-versa ) 
