### PR TITLE
Fix kdump/Fadump config

### DIFF
--- a/op-test
+++ b/op-test
@@ -693,15 +693,15 @@ class OSdumpfadumpSuite():
     def __init__(self):
         self.s = unittest.TestSuite()
         self.s.addTest(PowerNVDump.KernelCrash_FadumpEnable())
-        self.s.addTest(PowerNVDump.OpTestMakedump())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpDLPAR())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpWorkLoad())
         self.s.addTest(PowerNVDump.KernelCrash_hugepage_checks())
         self.s.addTest(PowerNVDump.KernelCrash_XIVE_off())
         self.s.addTest(PowerNVDump.KernelCrash_disable_radix())
-        self.s.addTest(PowerNVDump.KernelCrash_FadumpNocma())
+        self.s.addTest(PowerNVDump.OpTestMakedump())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpSSH())
         self.s.addTest(PowerNVDump.KernelCrash_KdumpNFS())
+        self.s.addTest(PowerNVDump.KernelCrash_FadumpNocma())
 
     def suite(self):
         return self.s


### PR DESCRIPTION
ServiceReport fails to estimate correct crashkernel size. This is a temporary fix to define crashkernel size