### PR TITLE
kdump verify dump needs timeout for copying kdump config file on SLES

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -247,7 +247,7 @@ class PowerNVDump(unittest.TestCase):
         if self.distro == "rhel":
             self.cv_HOST.host_run_command("cp /etc/kdump.conf_bck /etc/kdump.conf", timeout=60)
         if self.distro == "sles":
-            self.cv_HOST.host_run_command("cp /etc/sysconfig/kdump_bck /etc/sysconfig/kdump")
+            self.cv_HOST.host_run_command("cp /etc/sysconfig/kdump_bck /etc/sysconfig/kdump", timeout=60)
         if dump_place == "local":
             crash_content_after = self.c.run_command(
                 "ls -l /var/crash | grep '^d'| awk '{print $9}'")


### PR DESCRIPTION
There was a failure due to timeout during backup copy of kdump config file in SLES .This PR adds timeout similar to RHEL case.