### PR TITLE
Fix Syntax warnings on running ./op-test

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -381,7 +381,7 @@ class HMCUtil():
                                                  f" --filter 'lpar_names={self.lpar_name},"
                                                  f"profile_names={lpar_profile}' -F io_slots")
         log.info(f"assigned_io_slots:{assigned_io_slots}")
-        return [] if assigned_io_slots is "none" \
+        return [] if assigned_io_slots == "none" \
             else assigned_io_slots[0].replace('"', "").split(",")
 
     def get_lpar_name_for_ioslot(self, ioslot):

--- a/common/OpTestInstallUtil.py
+++ b/common/OpTestInstallUtil.py
@@ -90,7 +90,7 @@ class InstallUtil():
                 return True
             except CommandFailed as cf:
                 log.debug("wait_for_network CommandFailed={}".format(cf))
-                if cf.exitcode is 1:
+                if cf.exitcode == 1:
                     time.sleep(5)
                     retry = retry - 1
                     pass
@@ -118,7 +118,7 @@ class InstallUtil():
                 if retry == 1:
                     log.debug("ping_network raise cf={}".format(cf))
                     raise cf
-                if cf.exitcode is 1:
+                if cf.exitcode == 1:
                     time.sleep(5)
                     retry = retry - 1
                     log.debug(
@@ -217,7 +217,7 @@ class InstallUtil():
                 break
             except CommandFailed as cf:
                 log.debug("get_server_ip CommandFailed cf={}".format(cf))
-                if cf.exitcode is 1:
+                if cf.exitcode == 1:
                     time.sleep(1)
                     retry = retry - 1
                     pass

--- a/testcases/OpTestFastReboot.py
+++ b/testcases/OpTestFastReboot.py
@@ -118,7 +118,7 @@ class OpTestFastReboot(unittest.TestCase):
                               "/proc/device-tree/ibm,opal/fast-reboot: {}"
                               .format(fast_reboot_state[:-1]))
         except CommandFailed as cf:
-            if cf.exitcode is not 1:
+            if cf.exitcode != 1:
                 raise cf
 
         cpu = ''.join(c.run_command(

--- a/testcases/OpTestHMIHandling.py
+++ b/testcases/OpTestHMIHandling.py
@@ -213,7 +213,7 @@ class OpTestHMIHandling(unittest.TestCase):
         states = self.cv_HOST.host_run_command(
             "find /sys/devices/system/cpu/cpu*/cpuidle/state* -type d | cut -d'/' -f8 | sort -u | sed -e 's/^state//'", console=1)
         for state in states:
-            if state is "0":
+            if state == "0":
                 try:
                     self.cv_HOST.host_run_command(
                         "cpupower idle-set -e 0", console=1)

--- a/testcases/OpalMsglog.py
+++ b/testcases/OpalMsglog.py
@@ -127,7 +127,7 @@ class OpalMsglog():
             self.assertTrue(len(log_entries) == 0,
                             "Warnings/Errors in OPAL log:\n%s" % msg)
         except CommandFailed as cf:
-            if cf.exitcode is 1 and len(cf.output) is 0:
+            if cf.exitcode == 1 and len(cf.output) == 0:
                 # We have no warnings/errors!
                 pass
             else:


### PR DESCRIPTION
### Fix Syntax warnings on running ./op-test

Currently there are syntax warnings present in the code while running ./op-test test cases.
These syntax warnings are about using "==" and "!=" in place of "is" and "is not" respectively
This simple patch will eliminate the syntax warnings

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)