### PR TITLE
Fedora: handle ssh prompt with extra console chars

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1688,7 +1688,7 @@ class OpTestUtil():
         # Ctrl-L may cause a esc[J (erase) character to appear in the buffer.
         # Include this in the patterns that expect $ (end of line)
         rc = pty.expect(['login: (\x1b\[J)*$', ".*#(\x1b\[J)*$", ".*# (\x1b\[J)*$", ".*\$(\x1b\[J)*",
-                         "~>(\x1b\[J)", "~ #(\x1b\[J)", ":~(\x1b\[J)", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=30)
+                         "~>(\x1b\[J)", "~ #(\x1b\[J)", ":~(\x1b\[J)*", 'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=30)
         if rc == 0:
             track_obj.PS1_set, track_obj.LOGIN_set = self.get_login(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))


### PR DESCRIPTION
With fedora OS, the ssh login prompt has more extra brakceted console characters so make sure to include as wildcard

prompt:
^[]0;root@ltclp2:~^G^[[32mroot@ltcrain4-lp2^[[0m:^[[32m~^[[0m#^[[0m

error:
    self.connect(logger)
  File "/data/jenkins/workspace/sandbox/install/op-test/common/OpTestSSH.py", line 185, in connect
    self.check_set_term()
  File "/data/jenkins/workspace/sandbox/install/op-test/common/OpTestSSH.py", line 200, in check_set_term
    self.util.setup_term(self.system, self.pty,
  File "/", line 1709, in setup_term
    raise ConsoleSettings(before=pty.before, after=pty.after,
common.Exceptions.ConsoleSettings: Setting the prompt or logging in for the console was not successful, check credentials and review the following for more details Expect Before Buffer="command-line line 0: Unsupported option "afstokenpassing"

Last login: Tue Aug 13 03:11:16 2024
root@ltcrain4-lp2:~#
Expect After Buffer="<class 'pexpect.exceptions.EOF'>" Message="Getting login and sudo not successful, probably connection issue, retry"