### PR TITLE
Add timeout value for console based run commands in kdump tests

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1807,7 +1807,7 @@ class OpTestUtil():
                 raise CommandFailed(command, ''.join(failure_list_output), -1)
         return list_output, echo_rc
 
-    def run_command(self, term_obj, command, timeout=60, retry=0):
+    def run_command(self, term_obj, command, timeout=600, retry=5):
         # retry=0 will perform one pass
         counter = 0
         while counter <= retry:

--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -1144,7 +1144,6 @@ class KernelCrash_XIVE_off(PowerNVDump):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
         self.setup_test()
         log.info("=============== Testing kdump/fadump with xive=off ===============")
-        self.cv_SYSTEM.goto_state(OpSystemState.OS)
         obj = OpTestInstallUtil.InstallUtil()
         if not obj.update_kernel_cmdline(self.distro, args="xive=off",
                                          reboot=True, reboot_cmd=True):


### PR DESCRIPTION
We have observed  tests timing out with console  Warning .  kdump/fadump Makedumpfile testcase failed with timeout in Power9 CR.  To overcome this issue , added timeout as per the requirement . 

```
ERROR: runTest (testcases.PowerNVDump.OpTestMakedump)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/testcases/PowerNVDump.py", line 1311, in runTest
    self.makedump_check()
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/testcases/PowerNVDump.py", line 1267, in makedump_check
    "The dumpfiles are saved to dump3, and dump4")
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/testcases/PowerNVDump.py", line 1239, in check_run
    res = self.c.run_command(cmd)
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/common/OpTestHMC.py", line 1376, in run_command
    return self.util.run_command(self, i_cmd, timeout)
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/common/OpTestUtil.py", line 1820, in run_command
    raise cf
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/common/OpTestUtil.py", line 1815, in run_command
    output = self.try_command(term_obj, command, timeout)
  File "/var/lib/jenkins/workspace/TestRunner@2/op-test/common/OpTestUtil.py", line 1890, in try_command
    raise CommandFailed(command, res, echo_rc)
common.Exceptions.CommandFailed: Command 'makedumpfile --split -d 31 -l vmcore dump3 dump4' exited with '1'.
Output
['makedumpfile --split -d 31 -l vmcore dump3 dump4', '', 'Excluding unnecessary pages                       : [  0.0 %] /                  ', 'Excluding unnecessary pages                       : [ 60.0 %] |                  ', 'Excluding unnecessary pages                       : [100.0 %] \\                  ', 'Copying data                                      : [  5.4 %] -          eta: 11s', 'Copying data                                      : [  0.2 %] -        eta: 5m31s', 'Copying data                                      : [ 12.2 %] /          eta: 12s', 'Copying data                                      : [  0.5 %] /        eta: 5m31s', 'Copying data                                      : [  1.8 %] |        eta: 2m24s', 'Copying data                                      : [ 17.2 %] |          eta: 13s', 'Copying data                                      : [  3.9 %] \\          eta: 90s', 'Copying data                                      : [ 17.6 %] \\          eta: 17s', 'Copying data                                      : [ 19.3 %] -          eta: 20s', 'Copying data                                      : [  9.4 %] -          eta: 45s', 'Copying data                                      : [ 19.5 %] /          eta: 23s', 'Copying data                                      : [ 11.0 %] /          eta: 46s', 'Copying data                                      : [ 20.4 %] |          eta: 26s', 'Copying data                                      : [ 15.5 %] |          eta: 36s', 'Copying data                                      : [ 22.0 %] \\          eta: 27s', 'Copying data                                      : [ 16.5 %] \\          eta: 39s', 'Copying data                                      : [ 18.6 %] -          eta: 38s', 'Copying data                                      : [ 27.9 %] -          eta: 22s', 'Copying data                                      : [ 21.9 %] /          eta: 35s', 'Copying data                                      : [ 28.6 %] /          eta: 24s', 'Copying data                                      : [ 30.2 %] |          eta: 25s', 'Copying data                                      : [ 23.2 %] |          eta: 35s', 'Copying data                                      : [ 24.2 %] \\          eta: 37s', 'Copying data                                      : [ 30.4 %] \\          eta: 27s', 'Copying data                                      : [ 25.7 %] -          eta: 37s', 'Copying data                                      : [ 30.6 %] -          eta: 29s', 'Copying data                                      : [ 30.1 %] /          eta: 32s', 'Copying data                                      : [ 31.7 %] /          eta: 30s']

----------------------------------------------------------------------
Ran 9 tests in 4779.566s

FAILED (errors=1, skipped=2)
2024-08-14 13:47:11,586:op-test:<module>:INFO:Exit with Result errors="1" and failures="0"
```
