### PR TITLE
OpTestKernelTest: Add support for automated boot bisection v2.0

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1325,7 +1325,7 @@ class HMCConsole(HMCUtil):
             self.util.clear_state(self)
             self.connect(logger=logger)
             time.sleep(STALLTIME)
-            l_rc = self.pty.expect(["login:", pexpect.TIMEOUT], timeout=30)
+            l_rc = self.pty.expect(["login:", pexpect.TIMEOUT], timeout=80)
             if l_rc == 0:
                 self.pty.send('\r')
                 # In case when OS reboot/multireboot test and we lose prompt, reset prompt

--- a/common/OpTestSSH.py
+++ b/common/OpTestSSH.py
@@ -181,7 +181,7 @@ class OpTestSSH():
             self.pty.delaybeforesend = self.delaybeforesend
         self.pty.logfile_read = OpTestLogger.FileLikeLogger(self.log)
         # delay here in case messages like afstokenpassing unsupported show up which mess up setup_term
-        time.sleep(2)
+        time.sleep(5)
         self.check_set_term()
         log.debug("CONNECT starts Expect Buffer ID={}".format(hex(id(self.pty))))
         return self.pty

--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1658,7 +1658,7 @@ class OpTestUtil():
             return
 
         rc = pty.expect(['login: $', ".*#$", ".*# $", ".*\$", "~>", "~ #",
-                         'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=30)
+                         'Petitboot', pexpect.TIMEOUT, pexpect.EOF], timeout=60)
         if rc == 0:
             track_obj.PS1_set, track_obj.LOGIN_set = self.get_login(
                 system_obj.cv_HOST, term_obj, pty, self.build_prompt(system_obj.prompt))

--- a/testcases/OpTestKernelTest.py
+++ b/testcases/OpTestKernelTest.py
@@ -217,7 +217,7 @@ class KernelBuild(KernelTest):
         self.con.run_command("cd {}".format(self.home))
         if not self.branch:
             self.branch='master' 
-        self.con.run_command("git clone --depth 1 -b {} {} linux".format( self.branch, self.repo),timeout=3000)
+        self.con.run_command("git clone -b {} {} linux".format( self.branch, self.repo),timeout=3000)
         self.con.run_command("cd linux")
         commit = self.con.run_command(" git log -1 --format=%H  | sed -r 's/\x1B\[[0-9:]*[JKsu]//g'")
         self.con.run_command("cd ..")
@@ -271,7 +271,7 @@ class KernelBoot(KernelTest):
         self.con.run_command("cd {}".format(self.home))
         if not self.branch:
             self.branch='master'
-        self.con.run_command("git clone --depth 1 -b {} {} linux".format( self.branch, self.repo),timeout=3000)
+        self.con.run_command("git clone -b {} {} linux".format( self.branch, self.repo),timeout=3000)
         self.con.run_command("cd linux")
         commit = self.con.run_command(" git log -1 --format=%H  | sed -r 's/\x1B\[[0-9:]*[JKsu]//g'")
         self.con.run_command("cd ..")


### PR DESCRIPTION
This code is modifed and develped on top of the previous code (2f103 : OpTestKernelTest: Git bisect automation..)

With version 2.0 these are the new changes added:

1. Added support to handle nested bisection loop, which was not working with previous code
2. Modified code to work for end to end CI server
3. Better handle all cases of good flow and bad flow
4. Add json store of good boot commit for good run
5. Fix the previous code blocker to properly manage the console thread

TODO:
    Add boot json generation after bisection with bad commit
    Email format for boot bug report