### PR TITLE
Fixed the issue for seating the shared mode  EC vs VP value.

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -417,12 +417,23 @@ class HMCUtil():
         :param overcommit_ratio: overcommit ratio can be 1 to 5 for ideal cases
         '''
         if proc_mode == 'shared':
+            '''
+            Get the maximum configured virtual procs
+            '''
+            v_max_proc = 0
+            max_virtual_proc = self.run_command("lshwres -m %s -r proc --level sys -F curr_sys_virtual_procs" % (self.mg_system))
+            max_virtual_proc = int(max_virtual_proc[0])
+            if overcommit_ratio*int(max_proc_units) > max_virtual_proc:
+                v_max_proc = max_virtual_proc
+            else:
+                v_max_proc = overcommit_ratio*int(max_proc_units)
+
             self.set_lpar_cfg("proc_mode=shared,sharing_mode=%s,min_proc_units=%s,max_proc_units=%s,"
                               "desired_proc_units=%s,min_procs=%s,desired_procs=%s,max_procs=%s,"
                               "min_mem=%s,desired_mem=%s,max_mem=%s" %
-                              (sharing_mode, overcommit_ratio*int(min_proc_units), max_proc_units, overcommit_ratio*int(desired_proc_units),
-                               int(min_proc_units), 2*int(desired_proc_units),
-                               2*int(max_proc_units), min_memory, desired_memory, max_memory))
+                              (sharing_mode, min_proc_units, max_proc_units, desired_proc_units,
+                                  overcommit_ratio*int(min_proc_units),  overcommit_ratio*int(desired_proc_units), v_max_proc,
+                                  min_memory, desired_memory, max_memory))
         elif proc_mode == 'ded':
             self.set_lpar_cfg("proc_mode=ded,sharing_mode=%s,min_procs=%s,max_procs=%s,desired_procs=%s,"
                               "min_mem=%s,desired_mem=%s,max_mem=%s" %

--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -250,10 +250,9 @@ class LparConfig():
             except AttributeError:
                 self.desired_proc_units = 2.0
             try:
-                self.max_proc_units = int(float(
-                    self.cv_HMC.get_available_proc_resources()[0])) + self.cv_HMC.get_stealable_proc_resources_lpar()
+                self.max_proc_units = float(conf.args.max_proc_units)
             except AttributeError:
-                self.max_proc_units = 2.0
+                self.max_proc_units = int(float(self.cv_HMC.get_available_proc_resources()[0])) + self.cv_HMC.get_stealable_proc_resources_lpar()
             try:
                 self.overcommit_ratio = int(conf.args.overcommit_ratio)
             except AttributeError:


### PR DESCRIPTION
Fix EC Min/Desired Proc Units Calculation and Max Virtual Proc Units Logic

Previously, for EC, the `min_proc_units` were calculated by multiplying the user input with the `overcommit_ratio`. This caused an issue where users were unable to set their desired `min_proc_units` for EC. To fix this, the `overcommit_ratio` is no longer used in calculating `desired_proc_units`, as it should only be applied when determining the virtual proc units. The `desired_proc_units`, `max_proc_units` and `min_proc_units` are now set directly based on the user's inputs for EC.

Additionally, we added logic to calculate the max virtual proc units by fetching the maximum virtual procs configured in the system. We use this value as the max virtual proc count, but there is a condition where the available stealable resource count (multiplied by 2) is compared against the max virtual procs. If the multiplied stealable count is greater than the actual max virtual procs retrieved from the HMC command, we use the higher value, otherwise, we proceed with 2 * int(max_proc_units) for EC.