### PR TITLE
Fix servicereport argument for fadump package repair

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -641,7 +641,7 @@ class KernelCrash_FadumpEnable(PowerNVDump):
         self.cv_SYSTEM.set_state(OpSystemState.OS)
         if self.distro == "rhel":
             self.c.run_command("rm -rf ServiceReport; git clone https://github.com/linux-ras/ServiceReport; cd ServiceReport;"
-                               "python ./servicereport --plugins kdump package --repair", timeout=240)
+                               "python ./servicereport --plugins fadump package --repair", timeout=240)
             time.sleep(10)
             self.c.run_command("sed -e '/nfs/ s/^#*/#/' -i /etc/kdump.conf; sync")
             obj = OpTestInstallUtil.InstallUtil()


### PR DESCRIPTION
servicereport plugins  corrected to fadump  when the system under test was set to fadump mode .

```
# python ./servicereport --plugins fadump package --repair
servicereport 2.2.3

FADump configuration check                          PASS

  Active dump                                       PASS
  Dump component in initial ramdisk                 PASS
  FADump enabled check                              PASS
  FADump registration check                         PASS
  Service status                                    PASS
  kexec package                                     PASS
  Memory reservation                                PASS


Package availability check                          PASS

  ppc64-diag                                        PASS
  irqbalance                                        PASS
  perf                                              PASS
  sos                                               PASS
  powerpc-utils                                     PASS

#
------------
# kdumpctl status
kdump: Dump mode is fadump
```

