### PR TITLE
MachineConfig.py: osconfig command fails due to no prompt

### DIFF
--- a/testcases/MachineConfig.py
+++ b/testcases/MachineConfig.py
@@ -431,6 +431,8 @@ class LparConfig():
                     return "Failed to enable Performance Information collection"
 
         self.cv_HMC.poweron_lpar()
+        time.sleep(30)
+        self.cv_SYSTEM.console.close()
         curr_proc_mode = self.cv_HMC.get_proc_mode()
         if proc_mode:
             if proc_mode in curr_proc_mode:


### PR DESCRIPTION
For the below combination of MachineConfig the job fails {"lpar":"cpu=dedicated,vpmem=1,vtpm=1","os":"hugepage=2M"}

as the lparconfig power off and on the lpar and than the osconfig do not find the prompt ready to run os commands

so with this fix we are waiting for lpar os to boot till login and closing the console for next osConfig to open and reset the prompt and continue