### PR TITLE
Fix mkdumpfile timeout

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -1235,7 +1235,7 @@ class OpTestMakedump(PowerNVDump):
     '''
 
     def check_run(self, cmd, condition):
-        res = self.c.run_command(cmd)
+        res = self.c.run_command(cmd, timeout=300)
         for value in res:
             if condition in value:
                 log.info("command %s works well" % cmd)


### PR DESCRIPTION
OpTestMakedump testcases in kdump/fadump testsuite  were failing due to timeout issue . 

some of the commands execution took approximately  2 minutes  as shown below:

[console-expect]#time makedumpfile -d 31 -p vmcore dump43
The kernel version is not supported.
The makedumpfile operation may be incomplete.
Copying data                                      : [100.0 %] \           eta: 0s

The dumpfile is saved to dump43.

makedumpfile Completed.

real    1m51.007s
user    1m45.221s
sys     0m5.769s
[console-expect]#