### PR TITLE
Fixed EC vs VP setting for shared mode LPAR configuration.

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -424,9 +424,12 @@ class HMCUtil():
             max_virtual_proc = self.run_command("lshwres -m %s -r proc --level sys -F curr_sys_virtual_procs" % (self.mg_system))
             max_virtual_proc = int(max_virtual_proc[0])
             if overcommit_ratio*int(max_proc_units) > max_virtual_proc:
-                v_max_proc = max_virtual_proc
-            else:
+                 v_max_proc = max_virtual_proc
+             else:
                 v_max_proc = overcommit_ratio*int(max_proc_units)
+
+            if max_proc_units > v_max_proc:
+                max_proc_units = v_max_proc
 
             self.set_lpar_cfg("proc_mode=shared,sharing_mode=%s,min_proc_units=%s,max_proc_units=%s,"
                               "desired_proc_units=%s,min_procs=%s,desired_procs=%s,max_procs=%s,"


### PR DESCRIPTION
In the previously added code, it was observed that when the condition max_proc_units > max_virtual_proc is true, the system assigns the maximum virtual processors as returned by the LPAR configuration. However, an issue arises when the LPAR returns a maximum virtual processor count that is less than the max_proc_units. In such cases, the HMC fails to configure the EC vs VP values according to the virtual processors' thumb rule, which mandates that virtual processors should always be greater than or equal to EC processors.

This patch addresses and resolves the issue.