### PR TITLE
Updating grub cmd based OS version

### DIFF
--- a/testcases/InstallUpstreamKernel.py
+++ b/testcases/InstallUpstreamKernel.py
@@ -55,6 +55,7 @@ class InstallUpstreamKernel(unittest.TestCase):
         self.append_kernel_cmdline = self.conf.args.append_kernel_cmdline
         self.util = OpTestUtil(OpTestConfiguration.conf)
         self.host_distro_name = self.util.distro_name()
+        self.host_distro_version = self.util.get_distro_version()
         if self.config_path:
             self.config = "olddefconfig"
         if not self.repo:
@@ -159,8 +160,13 @@ class InstallUpstreamKernel(unittest.TestCase):
                         '%s /boot/vmlinu*-`uname -r`' % gruby_cmd)
                 elif self.host_distro_name in ['sles', 'SLES']:
                     con.run_command('%s /boot/vmlinu*-`uname -r`' % gruby_cmd)
-                con.run_command(
-                    "grub2-mkconfig  --output=/boot/grub2/grub.cfg")
+                if self.host_distro_name in ['rhel', 'Red Hat']:
+                    if self.host_distro_version.split()[0] <= "9.4":
+                        con.run_command(
+                            "grub2-mkconfig  --output=/boot/grub2/grub.cfg")
+                    else:
+                        con.run_command(
+                            "grub2-mkconfig  --output=/boot/grub2/grub.cfg --update-bls-cmdline")
                 con.run_command(kexec_cmdline)
                 boot_cmd = 'kexec -e'
             self.console_thread.console_terminate()


### PR DESCRIPTION
This Patch checks for the red-hat OS version and uses the appropriate grub cmd, based on the OS version.