### PR TITLE
Fixing Typecast issue

### DIFF
--- a/testcases/OpTestKernelTest.py
+++ b/testcases/OpTestKernelTest.py
@@ -107,7 +107,7 @@ class KernelTest(unittest.TestCase):
         log.debug("Compile the upstream kernel")
         try:
             cpu = self.cv_HOST.host_get_core_count()
-            err=self.con.run_command("make -j {} -s".format(cpu), timeout=self.host_cmd_timeout)
+            err=self.con.run_command("make -j {} -s".format(int(cpu)), timeout=self.host_cmd_timeout)
             log.info("Kernel build successful")
             return 0,err
         except CommandFailed as e:


### PR DESCRIPTION
Currently cpu value is being returned as floating point, which is resulting in make command failure. Changing it to return int value.

Below is the snippet of the logs before and after the change.

Before:

`console-expect]#make -j 9.0 -s
make -j 9.0 -s
make[1]: *** No rule to make target '9.0'.  Stop.
make: *** [Makefile:240: __sub-make] Error 2
[console-expect]#echo $?
echo $?
2`

After this patch:

`[console-expect]#make -j 9 -s
make -j 9 -s
# WRAP    arch/powerpc/include/generated/uapi/asm/bpf_perf_event.h
  echo "#include <asm-generic/bpf_perf_event.h>" > arch/powerpc/include/generated/uapi/asm/bpf_perf_event.h`