### PR TITLE
Sysinfo utility to record system information

### DIFF
--- a/CONFIG.YMAL
+++ b/CONFIG.YMAL
@@ -1,0 +1,6 @@
+LINUX:
+ COMMAND:
+ 	-"date"
+        -"hostname"
+        -"cat /etc/os-release | grep PRETTY_NAME "
+        -"uname -r"

--- a/CONFIG.YMAL
+++ b/CONFIG.YMAL
@@ -1,6 +1,6 @@
 LINUX:
- COMMAND:
- 	-"date"
-        -"hostname"
-        -"cat /etc/os-release | grep PRETTY_NAME "
-        -"uname -r"
+ COMMANDS:
+        - "date"
+        - "hostname"
+        - "cat /etc/os-release | grep PRETTY_NAME "
+        - "uname -r"

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -47,6 +47,7 @@ from common.OpTestSSH import OpTestSSH
 from common.OpTestUtil import OpTestUtil
 from common.Exceptions import CommandFailed
 from common import OPexpect
+from common.OpTestSysinfo import OpTestSysinfo
 
 from .OpTestConstants import OpTestConstants as BMC_CONST
 
@@ -160,6 +161,7 @@ class HMCUtil():
         self.PS1_set = -1
         self.LOGIN_set = -1
         self.SUDO_set = -1
+        self.sysinfo = OpTestSysinfo()
 
     def check_lpar_secureboot_state(self, hmc_con):
         '''
@@ -1349,6 +1351,9 @@ class HMCConsole(HMCUtil):
                     self.pty.send('\r')
                     log.debug("Waiting till booting!")
                     self.pty = self.get_login_prompt()
+
+        log.info("Collecting OS sysinfo") 
+        self.sysinfo.get_OSconfig(self.pty, self.expect_prompt)
 
         if self.system.SUDO_set != 1 or self.system.LOGIN_set != 1 or self.system.PS1_set != 1:
             self.util.setup_term(self.system, self.pty,

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1059,6 +1059,8 @@ class OpTestHMC(HMCUtil):
         self.system = system
         self.ssh.set_system(system)
         self.console.set_system(system)
+        log.info("Collecting OS sysinfo")
+        self.sysinfo.get_OSconfig(self.pty, self.expect_prompt)
 
     def get_rest_api(self):
         return None
@@ -1352,8 +1354,6 @@ class HMCConsole(HMCUtil):
                     log.debug("Waiting till booting!")
                     self.pty = self.get_login_prompt()
 
-        log.info("Collecting OS sysinfo") 
-        self.sysinfo.get_OSconfig(self.pty, self.expect_prompt)
 
         if self.system.SUDO_set != 1 or self.system.LOGIN_set != 1 or self.system.PS1_set != 1:
             self.util.setup_term(self.system, self.pty,

--- a/common/OpTestSysinfo.py
+++ b/common/OpTestSysinfo.py
@@ -47,6 +47,7 @@ from http.client import HTTPConnection
 import urllib3  # setUpChildLogger enables integrated logging with op-test
 import json
 import tempfile
+import yaml
 
 from common.OpTestSSH import OpTestSSH
 
@@ -54,24 +55,22 @@ import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
 
+config_file = "CONFIG.YMAL"
 
 class OpTestSysinfo():
 
     def __init__(self):
-        pass
+        with open(config_file, "r") as file:
+           self.config_actions = yaml.safe_load(file)
 
     def get_OSconfig(self, pty, prompt):
         # Collect config related data from the OS
         try:
+            list_of_commands = self.config_actions["LINUX"]["COMMANDS"]
             print("########### OS Sysinfo ########")
-            pty.sendline("date")  
-            pty.sendline("hostname")
-            pty.sendline("cat /etc/os-release | grep PRETTY_NAME ")
-            pty.sendline("uname -r")
-            pty.sendline("lsmcode")
-            pty.sendline("lparstat -i ")
-            pty.sendline("cat /proc/cpuinfo")
-            pty.sendline("lsmem | grep \"Memory block size\"")
+            for index, each_cmd in enumerate(list_of_commands, start=0):
+                pty.sendline(each_cmd)
+                rc = pty.expect([prompt, pexpect.TIMEOUT, pexpect.EOF], timeout=10)
         except CommandFailed as cf:
             raise cf
 

--- a/common/OpTestSysinfo.py
+++ b/common/OpTestSysinfo.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/common/OpTestUtil.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2015
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+
+import sys
+import os
+import datetime
+import time
+import pwd
+import string
+import subprocess
+import random
+import re
+import telnetlib
+import socket
+import select
+import time
+import pty
+import pexpect
+import subprocess
+import requests
+import traceback
+from requests.adapters import HTTPAdapter
+from http.client import HTTPConnection
+import urllib3  # setUpChildLogger enables integrated logging with op-test
+import json
+import tempfile
+
+from common.OpTestSSH import OpTestSSH
+
+import logging
+import OpTestLogger
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+
+class OpTestSysinfo():
+
+    def __init__(self):
+        pass
+
+    def get_OSconfig(self, pty, prompt):
+        # Collect config related data from the OS
+        try:
+            print("########### OS Sysinfo ########")
+            pty.sendline("date")  
+            pty.sendline("hostname")
+            pty.sendline("cat /etc/os-release | grep PRETTY_NAME ")
+            pty.sendline("uname -r")
+            pty.sendline("lsmcode")
+            pty.sendline("lparstat -i ")
+            pty.sendline("cat /proc/cpuinfo")
+            pty.sendline("lsmem | grep \"Memory block size\"")
+        except CommandFailed as cf:
+            raise cf
+
+    def get_HMCconfig(self, pty, prompt):
+        # Collect config data from HMC
+        try:
+            print("########### HMC Sysinfo ########")
+            pty.sendline("date")
+            pty.sendline("hostname")
+            pty.sendline("lshmv -V")
+        except CommandFailed as cf:
+            raise cf

--- a/common/OpTestSysinfo.py
+++ b/common/OpTestSysinfo.py
@@ -24,29 +24,8 @@
 #
 # IBM_PROLOG_END_TAG
 
-import sys
-import os
-import datetime
 import time
-import pwd
-import string
-import subprocess
-import random
-import re
-import telnetlib
-import socket
-import select
-import time
-import pty
 import pexpect
-import subprocess
-import requests
-import traceback
-from requests.adapters import HTTPAdapter
-from http.client import HTTPConnection
-import urllib3  # setUpChildLogger enables integrated logging with op-test
-import json
-import tempfile
 import yaml
 
 from common.OpTestSSH import OpTestSSH


### PR DESCRIPTION
This utility is designed to collect information across different test stack like OS, HMC, VIOS sysinfo etc..
sysinfo collected for every run before the test starts.

The flow is as below:
The OpTestSysinfo has different functions for different stack like OS, HMC, VIOS. Whenever the PS1 is initiated, the OpTestSysinfo module collects the data from the respective stack.