### PR TITLE
Fixing login timeout issue

### DIFF
--- a/common/OpTestUtil.py
+++ b/common/OpTestUtil.py
@@ -1474,13 +1474,12 @@ class OpTestUtil():
             return -1, -1
         my_user = host.username()
         my_pwd = host.password()
-        pty.sendline()
         rc = pty.expect(['login: ', pexpect.TIMEOUT, pexpect.EOF], timeout=60)
         if rc == 0:
             pty.sendline(my_user)
-            time.sleep(0.1)
+            time.sleep(3)
             rc = pty.expect(
-                [r"[Pp]assword:", pexpect.TIMEOUT, pexpect.EOF], timeout=60)
+                [r"[Pp]assword:", pexpect.TIMEOUT, pexpect.EOF], timeout=120)
             if rc == 0:
                 pty.sendline(my_pwd)
                 time.sleep(0.5)


### PR DESCRIPTION
Off-late observing a login timeout issue, specially when booted with upstream kernel.So to resolve this added a hack, by increasing the timeout after passing the username and also after passing the password. Also, removed a new line character.