### PR TITLE
Sysinfo utility to record system information

### DIFF
--- a/CONFIG.YAML
+++ b/CONFIG.YAML
@@ -1,0 +1,17 @@
+LINUX:
+ COMMANDS:
+        - "date"
+        - "hostname"
+        - "cat /etc/os-release | grep PRETTY_NAME"
+        - "uname -r"
+HMC:
+  COMMANDS:
+       - "lshmc -V"  #HMC software version, release, service pack, and build level
+       - "lssyscfg -r sys -F name,state,type_model,serial_num"  #List Managed Systems with on name,state,type_model,serial_num
+       - "lssyscfg -r lpar -m SYS -F name,state,os_version"   #Get system lpar's with name,state,os_version
+       - "lshwres -r proc -m SYS --level sys"  #Get proc resources available from sys
+       - "lshwres -r mem -m SYS --level sys"   #Get mem resources available from sys
+       - "lssyscfg -r lpar -m SYS -F name,lpar_env,state,os_version" #List All LPARs and Identify VIOS Partitions
+       - "lshwres -r virtualio --rsubtype eth -m SYS --level lpar" #Virtual Ethernet Adapter (VEA) Info
+       - "lshwres -r virtualio --rsubtype scsi -m SYS --level lpar" #scsi Adapter Info
+       - "lshwres -r virtualio --rsubtype fc -m SYS --level lpar"  #fc Adapter Info

--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1139,6 +1139,8 @@ class HMCConsole(HMCUtil):
         self.pty.set_system(system)
         log.info("Collecting OS sysinfo")
         self.sysinfo.get_OSconfig(self.pty, self.expect_prompt)
+        log.info("Collecting HMC details")
+        self.sysinfo.get_HMCconfig(self.ssh, self.expect_prompt,self.mg_system)
 
     def get_host_console(self):
         '''
@@ -1353,8 +1355,6 @@ class HMCConsole(HMCUtil):
                     self.pty.send('\r')
                     log.debug("Waiting till booting!")
                     self.pty = self.get_login_prompt()
-
-
         if self.system.SUDO_set != 1 or self.system.LOGIN_set != 1 or self.system.PS1_set != 1:
             self.util.setup_term(self.system, self.pty,
                                  None, self.system.block_setup_term)

--- a/common/OpTestSysinfo.py
+++ b/common/OpTestSysinfo.py
@@ -24,24 +24,24 @@
 #
 # IBM_PROLOG_END_TAG
 
+import OpTestConfiguration
 import time
 import pexpect
 import yaml
-
-from common.Exceptions import CommandFailed
+import re
 from common.OpTestSSH import OpTestSSH
-
 import logging
 import OpTestLogger
 log = OpTestLogger.optest_logger_glob.get_logger(__name__)
-
-config_file = "CONFIG.YMAL"
+config_file = "./CONFIG.YAML"
 
 class OpTestSysinfo():
 
     def __init__(self):
         with open(config_file, "r") as file:
-           self.config_actions = yaml.safe_load(file)
+            self.config_actions = yaml.safe_load(file)
+            list_of_commands = self.config_actions["LINUX"]["COMMANDS"]
+            get_HMCconfig_cmds  = self.config_actions["HMC"]["COMMANDS"]
 
     def get_OSconfig(self, pty, prompt):
         # Collect config related data from the OS
@@ -54,12 +54,20 @@ class OpTestSysinfo():
         except CommandFailed as cf:
             raise cf
 
-    def get_HMCconfig(self, pty, prompt):
+    def get_HMCconfig(self, pty, prompt,CEC_name):
         # Collect config data from HMC
-        try:
-            print("########### HMC Sysinfo ########")
-            pty.sendline("date")
-            pty.sendline("hostname")
-            pty.sendline("lshmv -V")
-        except CommandFailed as cf:
-            raise cf
+        ################ HMC INFO ####################
+        get_HMCconfig_cmds  = self.config_actions["HMC"]["COMMANDS"]
+        for index, each_cmd in enumerate(get_HMCconfig_cmds, start=0):
+             if re.search('SYS', each_cmd):
+                 new_cmd=re.sub('SYS',CEC_name,each_cmd)
+                 try:
+                   output = pty.run_command(new_cmd)
+                 except Exception as e: 
+                   print('command failed due to system error')
+             else:
+                try:
+                    output = pty.run_command(each_cmd)
+                except Exception as e:
+                          print('command failed due to system error')
+


### PR DESCRIPTION
This utility is designed to collect information across different test stack like OS, HMC, VIOS sysinfo etc..
sysinfo collected for every run before the test starts.

The flow is as below:
The OpTestSysinfo has different functions for different stack like OS, HMC, VIOS. Whenever the PS1 is initiated, the OpTestSysinfo module collects the data from the respective stack.