### PR TITLE
restart kdump service after copying cfg file

### DIFF
--- a/testcases/PowerNVDump.py
+++ b/testcases/PowerNVDump.py
@@ -246,9 +246,9 @@ class PowerNVDump(unittest.TestCase):
         Verify if dump file present
         '''
         if self.distro == "rhel":
-            self.cv_HOST.host_run_command("cp /etc/kdump.conf_bck /etc/kdump.conf", timeout=60)
+            self.cv_HOST.host_run_command("cp /etc/kdump.conf_bck /etc/kdump.conf; systemctl restart kdump.service", timeout=60)
         if self.distro == "sles":
-            self.cv_HOST.host_run_command("cp /etc/sysconfig/kdump_bck /etc/sysconfig/kdump", timeout=60)
+            self.cv_HOST.host_run_command("cp /etc/sysconfig/kdump_bck /etc/sysconfig/kdump; systemctl restart kdump.service", timeout=60)
         if dump_place == "local":
             crash_content_after = self.c.run_command(
                 "ls -l /var/crash | grep '^d'| awk '{print $9}'")


### PR DESCRIPTION
The patch takes care of restarting the kdump service after restoring to the original kdump cfg file.
When done, the next kdump iteration will run with the default kdump configuration. This will take care of post crash setup after the NFS, SSH kdump runs.