### PR TITLE
gitbisect: get online cpu count instead of cpu cores

### DIFF
--- a/common/OpTestHost.py
+++ b/common/OpTestHost.py
@@ -830,6 +830,15 @@ class OpTestHost():
         res = self.host_run_command("lscpu --all -e| wc -l", console=console)
         return int(res[0])/(self.host_get_smt(console=console))
 
+   def host_get_online_cpus(self, console=0):
+       '''
+       Get total online cpu count
+       return : cpus
+       type: int
+       '''
+       res = self.host_run_command("lscpu --online -e | wc -l", console=console)
+       return int(res[0])-1
+
     def host_gather_debug_logs(self, console=0):
         self.host_run_command(
             "grep ',[0-4]\]' /sys/firmware/opal/msglog", console=console)

--- a/testcases/OpTestKernelTest.py
+++ b/testcases/OpTestKernelTest.py
@@ -106,7 +106,7 @@ class KernelTest(unittest.TestCase):
         log.info("Upstream kernel commit-time: %s", tcommit)
         log.debug("Compile the upstream kernel")
         try:
-            cpu = self.cv_HOST.host_get_core_count()
+            cpu = self.cv_HOST.host_get_online_cpus()
             err=self.con.run_command("make -j {} -s".format(int(cpu)), timeout=self.host_cmd_timeout)
             log.info("Kernel build successful")
             return 0,err
@@ -130,7 +130,7 @@ class KernelTest(unittest.TestCase):
         self.con.run_command("make olddefconfig", timeout=60)
         base_version = self.con.run_command("uname -r")
         ker_ver = self.con.run_command("make kernelrelease")[-1]
-        cpu = self.cv_HOST.host_get_core_count()
+        cpu = self.cv_HOST.host_get_online_cpus()
         self.con.run_command("make -j {} -s".format(int(cpu)), timeout=60000)
         self.con.run_command("make modules_install", timeout=300)
         self.con.run_command("make install", timeout=120)


### PR DESCRIPTION
Add method to get online cpus instead of cpu cores replace host_get_core_count with host_get_online_cpus