### PR TITLE
IO test: Secure Boot NVMe 

### DIFF
--- a/common/OpTestHMC.py
+++ b/common/OpTestHMC.py
@@ -1571,3 +1571,14 @@ class HMCConsole(HMCUtil):
         Wrapper command for run_command from util
         '''
         return self.util.run_command(self, i_cmd, timeout)
+
+    def run_command_ignore_fail(self, command, timeout=15, retry=0):
+        '''
+        Wrapper command for run_command_ignore_fail from util.
+
+        Overrides HMCUtil.run_command_ignore_fail() which incorrectly
+        routes through self.ssh (the HMC SSH session) rather than the
+        LPAR pexpect console.  This override ensures that ignore-fail
+        commands run on the same LPAR console as run_command().
+        '''
+        return self.util.run_command_ignore_fail(self, command, timeout, retry)

--- a/common/OpTestHTXUtil.py
+++ b/common/OpTestHTXUtil.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2026
+# [+] International Business Machines Corp.
+# Maram Srimannarayana Murthy <msmurthy@linux.vnet.ibm.com>
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+'''
+OpTestHTXUtil
+-------------
+Reusable HTX utility for op-test.
+'''
+
+import re
+import subprocess
+import time
+
+import OpTestLogger
+
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+
+# ======================================================================= #
+#  Constants                                                               #
+# ======================================================================= #
+
+HTX_BASE_DIR    = '/usr/lpp/htx'
+HTX_MDT_DIR     = HTX_BASE_DIR + '/mdt'
+HTX_ERR_FILE    = '/tmp/htx/htxerr'
+HTX_D_STATUS    = HTX_BASE_DIR + '/etc/scripts/htx.d'
+HTX_D_RUN       = HTX_BASE_DIR + '/etc/scripts/htxd_run'
+HTX_D_SHUTDOWN  = HTX_BASE_DIR + '/etc/scripts/htxd_shutdown'
+DEFAULT_MDT     = 'mdt.hd'
+DEFAULT_RUN_TIME = 1800          # 30 minutes
+POLL_INTERVAL   = 60             # seconds between htxerr checks
+
+
+# ======================================================================= #
+#  OpTestHTXUtil                                                           #
+# ======================================================================= #
+
+class OpTestHTXUtil:
+    '''
+    Reusable HTX lifecycle manager for op-test test cases.
+    Manages HTX install, start, error polling, and stop on the target host.
+    '''
+
+    def __init__(self, console, ssh_host, distro_name, distro_version,
+                 rpm_link, run_time=DEFAULT_RUN_TIME):
+        self._console       = console
+        self._ssh           = ssh_host
+        self._distro_name   = distro_name.lower()
+        self._distro_version = str(distro_version).split('.')[0]
+        self._rpm_link      = (rpm_link or '').rstrip('/') + '/'
+        self._run_time      = int(run_time) if run_time else DEFAULT_RUN_TIME
+        self._started       = False
+        self._mdt           = DEFAULT_MDT
+
+        # Normalise suse → sles to match HTX RPM naming
+        if self._distro_name == 'suse':
+            self._distro_name = 'sles'
+
+    # ------------------------------------------------------------------ #
+    #  Public gate                                                         #
+    # ------------------------------------------------------------------ #
+
+    def is_configured(self):
+        '''
+        Return True only when an RPM link has been supplied.
+        All other public methods are no-ops when this returns False.
+        '''
+        return bool(self._rpm_link.strip('/'))
+
+    @property
+    def started(self):
+        '''True after start() succeeds, reset to False by stop().'''
+        return self._started
+
+    # ------------------------------------------------------------------ #
+    #  RPM installation                                                    #
+    # ------------------------------------------------------------------ #
+
+    def _fetch_rpm_name(self):
+        '''
+        Curl the RPM directory index and return the latest RPM filename
+        that matches the current distro/version pattern.
+
+        Uses subprocess on the *test driver* machine (not on the host)
+        — identical to OpTestHtxBootme.install_latest_htx_rpm().
+
+        Raises RuntimeError when no matching RPM is found.
+        '''
+        distro_pattern = '%s%s' % (self._distro_name, self._distro_version)
+        log.info("HTX: fetching RPM index from %s (pattern=%s)",
+                 self._rpm_link, distro_pattern)
+        try:
+            result = subprocess.run(
+                'curl --silent -k %s' % self._rpm_link,
+                shell=True, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, timeout=30,
+            )
+            index_html = result.stdout.decode('utf-8')
+        except Exception as exc:
+            raise RuntimeError(
+                "HTX: failed to fetch RPM index from %s: %s"
+                % (self._rpm_link, exc)
+            )
+
+        # Same regex used in avocado htx_test.py and OpTestHtxBootme
+        candidates = re.findall(
+            r'(?<=>)htx\w*-\d+-\w+\.\w+\.\w+', index_html
+        )
+        matching = sorted(
+            [r for r in candidates if distro_pattern in r], reverse=True
+        )
+        if not matching:
+            raise RuntimeError(
+                "HTX: no RPM found for pattern '%s' at %s"
+                % (distro_pattern, self._rpm_link)
+            )
+        log.info("HTX: resolved RPM → %s", matching[0])
+        return matching[0]
+
+    def _remove_existing_htx(self):
+        '''Remove any previously installed HTX RPM and directory.'''
+        old_pkgs = self._console.run_command_ignore_fail(
+            'rpm -qa | grep htx', timeout=60
+        )
+        for pkg in old_pkgs:
+            pkg = pkg.strip()
+            if pkg:
+                log.info("HTX: removing old package %s", pkg)
+                self._console.run_command_ignore_fail(
+                    'rpm -e %s' % pkg, timeout=60
+                )
+        self._console.run_command_ignore_fail(
+            'rm -rf %s' % HTX_BASE_DIR, timeout=60
+        )
+
+    def install(self):
+        '''
+        Install the latest distro-matching HTX RPM from rpm_link onto
+        the host, then start htxd and regenerate the MDT catalogue.
+
+        Steps
+        -----
+        1. Resolve the RPM filename from the directory index.
+        2. Remove any existing HTX installation.
+        3. wget the RPM onto the host and install it.
+        4. Start the HTX daemon (htxd_run).
+        5. Enable on-demand MDT creation and run htxcmdline -createmdt.
+
+        Raises RuntimeError on any installation failure so the caller
+        can treat it as a hard test error.
+        '''
+        if not self.is_configured():
+            log.info("HTX: rpm_link not set — skipping install")
+            return
+
+        rpm_name = self._fetch_rpm_name()
+        self._remove_existing_htx()
+
+        log.info("HTX: downloading %s onto host", rpm_name)
+        wget_cmd = (
+            'wget %s%s -O /tmp/%s --no-check-certificate'
+            % (self._rpm_link, rpm_name, rpm_name)
+        )
+        out = self._console.run_command(wget_cmd, timeout=300)
+        if any('ERROR' in l or 'error:' in l for l in out):
+            raise RuntimeError("HTX: wget failed for %s" % rpm_name)
+
+        log.info("HTX: installing %s", rpm_name)
+        install_cmd = 'rpm -ivh /tmp/%s --force' % rpm_name
+        out = self._console.run_command(install_cmd, timeout=180)
+        if any('ERROR' in l or 'error:' in l for l in out):
+            raise RuntimeError("HTX: rpm install failed for %s" % rpm_name)
+
+        # Clean up the downloaded RPM from /tmp
+        self._console.run_command_ignore_fail(
+            'rm -f /tmp/%s' % rpm_name, timeout=30
+        )
+
+        # Kill any stale htxd, then start fresh
+        self._console.run_command_ignore_fail('pkill -f htxd', timeout=15)
+        time.sleep(5)
+        log.info("HTX: starting htxd daemon")
+        self._console.run_command(HTX_D_RUN, timeout=30)
+
+        # Enable on-demand MDT so mdt.hd is always present
+        log.info("HTX: enabling on-demand MDT and creating catalogue")
+        self._console.run_command(
+            'hcl -set_htx_env HTX_ON_DEMAND_MDT_CREATION 1', timeout=30
+        )
+        self._console.run_command('htxcmdline -createmdt', timeout=60)
+        log.info("HTX: installation and MDT creation complete")
+
+    # ------------------------------------------------------------------ #
+    #  Run lifecycle                                                       #
+    # ------------------------------------------------------------------ #
+
+    def start(self, block_devs, mdt=DEFAULT_MDT):
+        '''
+        Select *mdt*, suspend all devices, activate the given block
+        devices, and start the HTX run.
+
+        Parameters
+        ----------
+        block_devs : list[str]
+            Bare block device names without /dev/, e.g.
+            ['nvme0n1', 'nvme1n1', 'sda', 'sdb'].
+            Works for any block device type (NVMe, SCSI, vSCSI LUN, etc.).
+        mdt : str
+            MDT filename to use (default: 'mdt.hd').
+
+        Does nothing when is_configured() is False or block_devs is empty.
+        '''
+        # is_configured() returns False when rpm_link was not supplied,
+        # meaning HTX is intentionally skipped for this test run.
+        if not self.is_configured() or not block_devs:
+            return
+
+        self._mdt = mdt
+        devs_str = ' '.join(block_devs)
+        log.info("HTX: selecting %s", mdt)
+        self._console.run_command(
+            'htxcmdline -select -mdt %s' % mdt
+        )
+
+        log.info("HTX: suspending all devices in %s", mdt)
+        self._console.run_command(
+            'htxcmdline -suspend all -mdt %s' % mdt
+        )
+
+        log.info("HTX: activating devices: %s", devs_str)
+        self._console.run_command(
+            'htxcmdline -activate %s -mdt %s' % (devs_str, mdt)
+        )
+
+        log.info("HTX: starting run on %s with mdt=%s", devs_str, mdt)
+        self._console.run_command('htxcmdline -run -mdt %s' % mdt)
+        self._started = True
+
+    # ------------------------------------------------------------------ #
+    #  Error polling                                                       #
+    # ------------------------------------------------------------------ #
+
+    def wait_and_check(self):
+        '''
+        Poll /tmp/htx/htxerr every POLL_INTERVAL seconds for
+        self._run_time total seconds.
+
+        Returns a list of failure strings (empty list = clean run).
+        Stops polling early on the first error detected.
+        '''
+        if not self.is_configured() or not self._started:
+            return []
+
+        failures = []
+        elapsed  = 0
+        log.info(
+            "HTX: running %s for %d seconds (%d min)",
+            self._mdt, self._run_time, self._run_time // 60,
+        )
+
+        while elapsed < self._run_time:
+            sleep_for = min(POLL_INTERVAL, self._run_time - elapsed)
+            time.sleep(sleep_for)
+            elapsed += sleep_for
+
+            try:
+                err_size_out = self._ssh.run_command(
+                    'wc -c %s' % HTX_ERR_FILE
+                )
+                err_bytes = int(err_size_out[0].split()[0])
+            except (IndexError, ValueError, Exception) as exc:
+                log.warning(
+                    "HTX: could not read htxerr size at t+%ds: %s",
+                    elapsed, exc,
+                )
+                continue
+
+            if err_bytes != 0:
+                failures.append(
+                    "HTX htxerr non-empty (%d bytes) at t+%ds — "
+                    "inspect %s on the host for details"
+                    % (err_bytes, elapsed, HTX_ERR_FILE)
+                )
+                log.error(
+                    "HTX: htxerr non-empty (%d bytes) at t+%ds",
+                    err_bytes, elapsed,
+                )
+                break
+
+            # Check dmesg for hardware/IO errors during the HTX run.
+            # Avoid --since (requires util-linux >= 2.32); use line-count
+            # delta instead — works on all RHEL 8+ and SLES 15+ targets.
+            try:
+                dmesg_out = self._ssh.run_command(
+                    'dmesg --level=err,crit,alert,emerg 2>/dev/null'
+                    ' | tail -n 20'
+                )
+                dmesg_errors = [l for l in dmesg_out if l.strip()]
+                if dmesg_errors:
+                    failures.append(
+                        "HTX: dmesg errors at t+%ds:\n    %s"
+                        % (elapsed, '\n    '.join(dmesg_errors))
+                    )
+                    log.error("HTX: dmesg errors at t+%ds: %s",
+                              elapsed, dmesg_errors)
+                    break
+            except Exception as exc:
+                log.warning("HTX: dmesg check failed at t+%ds: %s",
+                            elapsed, exc)
+
+            log.info(
+                "HTX: t+%ds / %ds — htxerr clean",
+                elapsed, self._run_time,
+            )
+
+        return failures
+
+    # ------------------------------------------------------------------ #
+    #  Shutdown                                                            #
+    # ------------------------------------------------------------------ #
+
+    def stop(self):
+        '''
+        Shutdown the active MDT and stop the HTX daemon if still running.
+        Safe to call even when start() was never reached (no-op in that
+        case for the daemon check).
+        '''
+        # No-op when HTX was never configured (rpm_link not supplied).
+        if not self.is_configured():
+            return
+
+        log.info("HTX: shutting down mdt %s", self._mdt)
+        self._console.run_command_ignore_fail(
+            'htxcmdline -shutdown -mdt %s' % self._mdt, timeout=120
+        )
+
+        daemon_out = self._console.run_command_ignore_fail(
+            '%s status' % HTX_D_STATUS, timeout=60
+        )
+        if any('running' in l for l in daemon_out):
+            log.info("HTX: stopping htxd daemon")
+            self._console.run_command_ignore_fail(
+                HTX_D_SHUTDOWN, timeout=120
+            )
+
+        self._started = False
+        log.info("HTX: shutdown complete")

--- a/testcases/OpTestSecureBootIO.py
+++ b/testcases/OpTestSecureBootIO.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+# IBM_PROLOG_BEGIN_TAG
+# This is an automatically generated prolog.
+#
+# $Source: op-test-framework/testcases/OpTestSecureBootIO.py $
+#
+# OpenPOWER Automated Test Project
+#
+# Contributors Listed Below - COPYRIGHT 2026
+# [+] Maram Srimannarayana Murthy <msmurthy@linux.vnet.ibm.com>
+# [+] International Business Machines Corp.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# IBM_PROLOG_END_TAG
+'''
+OpTestSecureBootIO
+------------------
+Validates that IO device state is preserved across a Secure Boot enable
+transition on IBM Power LPARs (RHEL/SUSE, ppc64le).
+
+Each IO device type (NVMe, FC, vSCSI) is encapsulated in its own plugin
+class derived from IODevicePlugin.  Adding a new device type requires only
+a new plugin class and a new runnable test class — no changes to the base
+flow are needed.
+'''
+import re
+import unittest
+import OpTestConfiguration
+import OpTestLogger
+
+from common.OpTestSystem import OpSystemState
+from common.OpTestUtil import OpTestUtil
+from common.OpTestHTXUtil import OpTestHTXUtil
+
+log = OpTestLogger.optest_logger_glob.get_logger(__name__)
+
+
+# ======================================================================= #
+#  IO Device Plugin Base Class                                             #
+# ======================================================================= #
+
+class IODevicePlugin:
+    '''
+    Abstract base for IO device plugins.
+
+    Each subclass encapsulates one device type (NVMe, FC, vSCSI, ...) and
+    must implement collect() and compare().  The test host console handle
+    is injected at construction time.
+    '''
+
+    def __init__(self, console):
+        self.c = console
+
+    def is_available(self):
+        '''Return True if this device type is present on the host.'''
+        raise NotImplementedError
+
+    def collect(self):
+        '''
+        Capture device state and return a dict snapshot.
+        All keys in the returned dict must be stable across reboots.
+        '''
+        raise NotImplementedError
+
+    def compare(self, baseline, snapshot):
+        '''
+        Compare baseline dict to snapshot dict.
+        Return a list of failure strings (empty list means pass).
+        '''
+        raise NotImplementedError
+
+
+# ======================================================================= #
+#  NVMe Plugin                                                             #
+# ======================================================================= #
+
+class NVMePlugin(IODevicePlugin):
+    '''
+    IO device plugin for NVMe PCIe-attached controllers.
+
+    Controller identity is keyed by serial number (SN) from nvme id-ctrl.
+    Fallback to NQN-embedded SN, then to PCI address when id-ctrl fails.
+    An optional filter list (set of tokens) limits which controllers are
+    included; empty filter means all discovered controllers.
+    '''
+
+    def __init__(self, console, device_filter=None):
+        super().__init__(console)
+        self._filter = device_filter or set()
+        self._serial_to_dev = {}
+
+    # ------------------------------------------------------------------ #
+
+    def _parse_subsys_map(self):
+        '''
+        Parse 'nvme list-subsys' and return a per-controller dict.
+        Returns: { 'nvmeX': { 'pci': '<addr>', 'nqn': '<NQN>' }, ... }
+        '''
+        out = self.c.run_command_ignore_fail('nvme list-subsys')
+        pci_re = re.compile(
+            r'^\s*\+-\s+(nvme\d+)\s+pcie\s+(?:traddr=)?'
+            r'([\da-fA-F]{4}:[\da-fA-F]{2}:[\da-fA-F]{2}\.\d)'
+        )
+        nqn_re = re.compile(r'NQN=(\S+)')
+        result = {}
+        current_nqn = ''
+        for line in out:
+            m = nqn_re.search(line)
+            if m:
+                current_nqn = m.group(1)
+                continue
+            m = pci_re.match(line)
+            if m:
+                result[m.group(1)] = {
+                    'pci': m.group(2),
+                    'nqn': current_nqn,
+                }
+        return result
+
+    @staticmethod
+    def _sn_from_nqn(nqn):
+        '''
+        Extract a serial-number candidate from the last colon segment of an NQN.
+        Returns the segment if it is 6–24 alphanumeric characters, else ''.
+        '''
+        if not nqn:
+            return ''
+        candidate = nqn.rstrip().split(':')[-1]
+        return candidate if re.match(r'^[A-Za-z0-9]{6,24}$', candidate) else ''
+
+    def _resolve_identity(self, ctrl, subsys_map):
+        '''
+        Resolve the stable identity key for a controller.
+        Priority: id-ctrl SN > NQN-embedded SN > PCI address.
+        Returns (identity_key, pci_addr) or (None, pci_addr) to skip.
+        '''
+        ctrl_name = ctrl.replace('/dev/', '')
+        pci_addr = subsys_map.get(ctrl_name, {}).get('pci', '')
+        nqn = subsys_map.get(ctrl_name, {}).get('nqn', '')
+
+        sn = ''
+        sn_out = self.c.run_command_ignore_fail(
+            "nvme id-ctrl %s | grep '^sn'" % ctrl
+        )
+        for line in sn_out:
+            if line.startswith('sn'):
+                sn = line.split(':', 1)[-1].strip()
+                break
+
+        if not sn:
+            sn = self._sn_from_nqn(nqn)
+            if sn:
+                log.warning("%s: using NQN-derived SN '%s'", ctrl, sn)
+
+        if sn:
+            return sn, pci_addr
+
+        if pci_addr:
+            identity = 'pci:' + pci_addr
+            log.warning("%s: using PCI address key '%s'", ctrl, identity)
+            return identity, pci_addr
+
+        log.warning("%s: SN and PCI address unavailable — skipping", ctrl)
+        return None, pci_addr
+
+    def _build_serial_map(self):
+        '''
+        Build self._serial_to_dev = { identity_key: '/dev/nvmeX' }.
+        Applies self._filter if non-empty.  Skips if no controllers found.
+        '''
+        subsys_map = self._parse_subsys_map()
+        out = self.c.run_command('nvme list')
+        ctrl_paths = []
+        for line in out:
+            if not line.startswith('/dev/nvme'):
+                continue
+            ctrl_name = re.sub(r'n\d+$', '', line.split()[0].replace('/dev/', ''))
+            ctrl_path = '/dev/' + ctrl_name
+            if ctrl_path not in ctrl_paths:
+                ctrl_paths.append(ctrl_path)
+
+        serial_map = {}
+        for ctrl in ctrl_paths:
+            ctrl_name = ctrl.replace('/dev/', '')
+            identity, pci_addr = self._resolve_identity(ctrl, subsys_map)
+            if not identity:
+                continue
+            if self._filter:
+                if not (identity in self._filter
+                        or ctrl_name in self._filter
+                        or (pci_addr and pci_addr in self._filter)):
+                    continue
+            serial_map[identity] = ctrl
+            log.info("Mapped %-32s  →  %s  (pci=%s)",
+                     identity, ctrl, pci_addr or 'unknown')
+
+        self._serial_to_dev = serial_map
+
+    # ------------------------------------------------------------------ #
+
+    def is_available(self):
+        '''Return True if at least one NVMe controller is listed.'''
+        out = self.c.run_command_ignore_fail('nvme list')
+        return any(line.startswith('/dev/nvme') for line in out)
+
+    def collect(self):
+        '''
+        Capture NVMe controller/namespace/queue state.
+        Returns a dict keyed by serial number where applicable.
+        All identity keys are stable across reboots.
+        '''
+        self._build_serial_map()
+        if not self._serial_to_dev:
+            return {}
+
+        data = {}
+
+        nvme_list_out = self.c.run_command('nvme list')
+        serials = set()
+        for line in nvme_list_out:
+            if line.startswith('/dev/nvme'):
+                fields = line.split()
+                if len(fields) >= 3:
+                    serials.add(fields[2].strip())
+        data['nvme_list_serials'] = serials
+
+        subsys_out = self.c.run_command('nvme list-subsys')
+        nqns = set()
+        for line in subsys_out:
+            m = re.search(r'NQN=(\S+)', line)
+            if m:
+                nqns.add(m.group(1))
+        data['subsys_nqns'] = nqns
+
+        lsmod_out = self.c.run_command('lsmod | grep nvme')
+        loaded = {line.split()[0] for line in lsmod_out if line.split()}
+        data['nvme_core_loaded'] = 'nvme_core' in loaded
+        data['nvme_loaded'] = 'nvme' in loaded
+
+        modinfo_out = self.c.run_command_ignore_fail(
+            r"modinfo nvme | grep '^signer'"
+        )
+        data['mod_signer'] = ''
+        for line in modinfo_out:
+            if line.startswith('signer'):
+                data['mod_signer'] = line.split(':', 1)[-1].strip()
+                break
+
+        lsblk_out = self.c.run_command(
+            "lsblk --noheadings -o SERIAL,TRAN | grep nvme"
+        )
+        data['lsblk_serials'] = {
+            line.split()[0].strip() for line in lsblk_out if line.split()
+        }
+
+        data['id_ctrl'] = {}
+        data['list_ns'] = {}
+        for sn, dev in self._serial_to_dev.items():
+            data['id_ctrl'][sn] = self.c.run_command(
+                r"nvme id-ctrl %s | grep -E '^mn|^sn|^fr|^nn|^frmw'" % dev
+            )
+            data['list_ns'][sn] = self.c.run_command('nvme list-ns %s' % dev)
+
+        data['queue_attrs'] = {}
+        for sn, ctrl_dev in self._serial_to_dev.items():
+            ctrl_name = ctrl_dev.replace('/dev/', '')
+            ns_out = self.c.run_command_ignore_fail(
+                "lsblk --noheadings -o NAME,TYPE %s "
+                "| awk '$2==\"disk\"{print $1}'" % ctrl_dev
+            )
+            ns_name = ''
+            for line in ns_out:
+                if re.match(r'^nvme\d+n\d+$', line.strip()):
+                    ns_name = line.strip()
+                    break
+            if not ns_name:
+                ns_name = ctrl_name + 'n1'
+
+            attrs = {}
+            for attr in ('physical_block_size', 'logical_block_size',
+                         'minimum_io_size', 'optimal_io_size'):
+                out = self.c.run_command_ignore_fail(
+                    'cat /sys/block/%s/queue/%s' % (ns_name, attr)
+                )
+                if out:
+                    attrs[attr] = out[0].strip()
+            data['queue_attrs'][sn] = attrs
+
+        return data
+
+    def compare(self, baseline, snapshot):
+        '''
+        Compare NVMe baseline vs snapshot dicts.
+        Returns a list of failure strings.
+        '''
+        failures = []
+
+        def _set_diff(key, label):
+            b = baseline.get(key, set())
+            s = snapshot.get(key, set())
+            missing = b - s
+            extra = s - b
+            if missing:
+                failures.append(
+                    "MISSING %s after SB enable: %s"
+                    % (label, ', '.join(sorted(missing)))
+                )
+            if extra:
+                failures.append(
+                    "UNEXPECTED new %s after SB enable: %s"
+                    % (label, ', '.join(sorted(extra)))
+                )
+
+        _set_diff('nvme_list_serials', 'controllers (nvme list serials)')
+        _set_diff('subsys_nqns', 'subsystem NQNs')
+        _set_diff('lsblk_serials', 'block devices (lsblk serials)')
+
+        for mod_key, mod_name in (('nvme_core_loaded', 'nvme_core'),
+                                  ('nvme_loaded', 'nvme')):
+            if baseline.get(mod_key) and not snapshot.get(mod_key):
+                failures.append(
+                    "MODULE MISSING: '%s' absent after SB enable" % mod_name
+                )
+
+        b_signer = baseline.get('mod_signer', '')
+        s_signer = snapshot.get('mod_signer', '')
+        if b_signer and s_signer and b_signer != s_signer:
+            failures.append(
+                "MISMATCH mod_signer: '%s' → '%s'" % (b_signer, s_signer)
+            )
+
+        for sn in baseline.get('id_ctrl', {}):
+            if sn not in snapshot.get('id_ctrl', {}):
+                failures.append("MISSING id_ctrl for SN=%s" % sn)
+            elif baseline['id_ctrl'][sn] != snapshot['id_ctrl'][sn]:
+                failures.append(
+                    "MISMATCH id_ctrl[SN=%s]: BEFORE=%s AFTER=%s"
+                    % (sn,
+                       ' | '.join(baseline['id_ctrl'][sn]),
+                       ' | '.join(snapshot['id_ctrl'][sn]))
+                )
+
+        for sn in baseline.get('list_ns', {}):
+            if sn not in snapshot.get('list_ns', {}):
+                failures.append("MISSING list_ns for SN=%s" % sn)
+            elif baseline['list_ns'][sn] != snapshot['list_ns'][sn]:
+                failures.append(
+                    "MISMATCH list_ns[SN=%s]: BEFORE=%s AFTER=%s"
+                    % (sn,
+                       ' | '.join(baseline['list_ns'][sn]),
+                       ' | '.join(snapshot['list_ns'][sn]))
+                )
+
+        b_qa = baseline.get('queue_attrs', {})
+        s_qa = snapshot.get('queue_attrs', {})
+        for sn in b_qa:
+            for attr, b_val in b_qa[sn].items():
+                s_val = s_qa.get(sn, {}).get(attr, '')
+                if s_val and b_val != s_val:
+                    failures.append(
+                        "MISMATCH queue_attrs[SN=%s][%s]: %s → %s"
+                        % (sn, attr, b_val, s_val)
+                    )
+
+        nvme_present = bool(
+            self.c.run_command_ignore_fail('command -v nvme')
+        )
+        if nvme_present:
+            for sn, dev in self._serial_to_dev.items():
+                out = self.c.run_command_ignore_fail(
+                    'nvme show-regs %s -H' % dev
+                )
+                out_text = ' '.join(out).lower()
+                if not any(kw in out_text for kw in
+                           ('permission', 'eperm',
+                            'operation not permitted', 'lockdown')):
+                    failures.append(
+                        "LOCKDOWN BYPASS: 'nvme show-regs %s -H' (SN=%s) "
+                        "succeeded under lockdown=integrity — expected EPERM"
+                        % (dev, sn)
+                    )
+
+        return failures
+
+
+# ======================================================================= #
+#  Secure Boot IO Base Test Class                                          #
+# ======================================================================= #
+
+class OpTestSecureBootIO(unittest.TestCase):
+    '''
+    Base class for IO integrity validation across a Secure Boot enable cycle.
+
+    Subclasses provide a populated self.io_plugins list of IODevicePlugin
+    instances.  The 8-phase flow is device-type agnostic: collect baseline,
+    enable SB, collect snapshot, diff, then optionally run HTX on block
+    devices.  Adding a new IO type requires only a new IODevicePlugin
+    subclass and a new test class.
+
+    HTX (Phases 7-8) is only entered when a subclass constructs an
+    OpTestHTXUtil instance and assigns it to self._htx_util.  The base
+    class initialises self._htx_util to None so non-block-device subclasses
+    (FC, vSCSI, …) are never affected.
+    '''
+
+    # Subclasses set this to the list of IODevicePlugin instances to exercise.
+    io_plugins = []
+
+    def setUp(self):
+        conf = OpTestConfiguration.conf
+
+        if conf.args.bmc_type not in ('FSP_PHYP', 'EBMC_PHYP'):
+            self.skipTest(
+                "OpTestSecureBootIO requires bmc_type FSP_PHYP or EBMC_PHYP"
+            )
+
+        self.cv_SYSTEM = conf.system()
+        self.cv_HOST = conf.host()
+        self.cv_HMC = self.cv_SYSTEM.hmc
+        self.c = self.cv_HMC.get_host_console()
+        self.hmc_con = self.cv_HMC.ssh
+        self.util = OpTestUtil(conf)
+
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        os_level = self.cv_HOST.host_get_OS_Level()
+        if 'Red Hat' in os_level:
+            self.distro = 'rhel'
+        elif 'SLES' in os_level:
+            self.distro = 'sles'
+        else:
+            self.skipTest(
+                "OpTestSecureBootIO: unsupported distro — RHEL and SUSE only"
+            )
+
+        # HTX utility: None means Phases 7-8 are skipped.
+        # Block-device subclasses (e.g. NVMeSecureBootIO) override this in
+        # their own setUp() after calling super().setUp().
+        self._htx_util = None
+
+    # ------------------------------------------------------------------ #
+
+    def _enable_secureboot_via_hmc(self):
+        '''
+        PHASE 3 — OS-level SB prep followed by HMC power-cycle.
+        '''
+        log.info("PHASE 3: OS-level Secure Boot preparation")
+        self.util.os_secureboot_enable(enable=True)
+
+        log.info("PHASE 3: Powering off LPAR")
+        self.cv_HMC.poweroff_lpar()
+
+        log.info("PHASE 3: Setting secure_boot=2 via HMC chsyscfg")
+        cmd = (
+            'chsyscfg -r lpar -m %s -i "name=%s, secure_boot=2"'
+            % (self.cv_HMC.mg_system, self.cv_HMC.lpar_name)
+        )
+        self.hmc_con.run_command(cmd, timeout=300)
+
+        log.info("PHASE 3: Booting LPAR to OS with Secure Boot enabled")
+        self.cv_SYSTEM.goto_state(OpSystemState.OFF)
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+
+    # ------------------------------------------------------------------ #
+
+    def _disable_secureboot_via_hmc(self):
+        '''
+        TEARDOWN — Disable Secure Boot via HMC and restore LPAR to OS.
+
+        Steps (per requirement):
+          1. Shutdown LPAR.
+          2. Disable Secure Boot (secure_boot=0) via HMC chsyscfg.
+          3. Power on LPAR and wait for OS.
+        '''
+        log.info("TEARDOWN: Shutting down LPAR")
+        self.cv_HMC.poweroff_lpar()
+
+        log.info("TEARDOWN: Disabling Secure Boot via HMC (secure_boot=0)")
+        self.cv_HMC.hmc_secureboot_on_off(enable=False)
+
+        # Reset the state-machine to OFF so that goto_state(OS) actually
+        # powers on the LPAR.  poweroff_lpar() shuts down the hardware but
+        # does not update the OpTestSystem state cache; if it still reads OS
+        # (6), goto_state(OS) calls run_OS(OS) which returns immediately
+        # without issuing any power-on command, leaving the LPAR off.
+        self.cv_SYSTEM.set_state(OpSystemState.OFF)
+
+        log.info("TEARDOWN: Powering on LPAR and waiting for OS")
+        self.cv_SYSTEM.goto_state(OpSystemState.OS)
+        log.info("TEARDOWN: Secure Boot disabled; LPAR is back in OS")
+
+    # ------------------------------------------------------------------ #
+
+    def tearDown(self):
+        '''
+        Post-test teardown: stop HTX if started, then optionally disable SB.
+
+        HTX stop is unconditional whenever OpTestHTXUtil was started,
+        ensuring the daemon is never left running after a mid-phase failure.
+
+        SB disable runs only when --disable-secureboot-after-test is set.
+        '''
+        # --- HTX cleanup (unconditional when the util was started) ------- #
+        if self._htx_util is not None and self._htx_util.started:
+            log.info("TEARDOWN: stopping HTX (safety cleanup)")
+            try:
+                self._htx_util.stop()
+            except Exception as exc:
+                log.warning("TEARDOWN: HTX stop raised: %s", exc)
+
+        # --- Secure Boot disable (opt-in via cfg flag) ------------------- #
+        disable_after = getattr(
+            OpTestConfiguration.conf.args,
+            'disable_secureboot_after_test',
+            False,
+        )
+        if not disable_after:
+            return
+
+        sb_on = self.cv_HMC.check_lpar_secureboot_state(self.hmc_con)
+        if not sb_on:
+            log.info("TEARDOWN: Secure Boot already disabled — no action needed")
+            return
+
+        try:
+            log.info("TEARDOWN: Disabling Secure Boot at OS level")
+            self.util.os_secureboot_enable(enable=False)
+        except Exception as exc:
+            log.warning("TEARDOWN: OS-level SB disable raised: %s — "
+                        "continuing with HMC disable", exc)
+        self._disable_secureboot_via_hmc()
+
+    # ------------------------------------------------------------------ #
+
+    def _collect_sb_state(self):
+        '''
+        Collect lockdown sysfs value and OS-level SB property.
+        Returns a dict with keys: lockdown_state, dt_sb_enabled.
+        '''
+        data = {}
+
+        lockdown_out = self.c.run_command(
+            'cat /sys/kernel/security/lockdown'
+        )
+        m = re.search(r'\[(\w+)\]', ' '.join(lockdown_out))
+        data['lockdown_state'] = m.group(1) if m else ''
+
+        data['dt_sb_enabled'] = self.util.check_os_level_secureboot_state()
+        return data
+
+    # ------------------------------------------------------------------ #
+
+    def _compare_sb_state(self, baseline_sb, snapshot_sb):
+        '''
+        Validate must-change SB indicators in the post-SB snapshot.
+        Returns a list of failure strings.
+        '''
+        failures = []
+
+        if snapshot_sb.get('lockdown_state') != 'integrity':
+            failures.append(
+                "MUST-CHANGE lockdown_state: expected 'integrity', "
+                "got: '%s'" % snapshot_sb.get('lockdown_state', '')
+            )
+
+        if not snapshot_sb.get('dt_sb_enabled'):
+            failures.append(
+                "MUST-CHANGE dt_sb: '00000002' not found in "
+                "lsprop /proc/device-tree/ibm,secure-boot"
+            )
+
+        return failures
+
+    # ------------------------------------------------------------------ #
+
+    def runTest(self):
+        '''
+        Orchestrates the Secure Boot IO + optional HTX validation flow.
+        Phases 7-8 (HTX) are entered only when self._htx_util is configured.
+        '''
+        active_plugins = [p for p in self.io_plugins if p.is_available()]
+        if not active_plugins:
+            self.skipTest(
+                "No configured IO devices found on host — skipping"
+            )
+
+        log.info("PHASE 1: Capturing IO baseline (pre-Secure Boot)")
+        baselines = {p: p.collect() for p in active_plugins}
+        baseline_sb = self._collect_sb_state()
+
+        log.info("PHASE 2: Checking current Secure Boot state")
+        sb_on = self.cv_HMC.check_lpar_secureboot_state(self.hmc_con)
+        if sb_on:
+            log.warning(
+                "PHASE 2: Secure Boot already enabled — skipping PHASE 3"
+            )
+        else:
+            log.info("PHASE 3: Enabling Secure Boot via OS prep + HMC")
+            self._enable_secureboot_via_hmc()
+
+        log.info("PHASE 4: Collecting post-SB state indicators")
+        snapshot_sb = self._collect_sb_state()
+
+        log.info("PHASE 5: Capturing IO snapshot (post-Secure Boot)")
+        snapshots = {p: p.collect() for p in active_plugins}
+
+        log.info("PHASE 6: Comparing baseline vs post-SB snapshot")
+        all_failures = self._compare_sb_state(baseline_sb, snapshot_sb)
+        for plugin in active_plugins:
+            all_failures.extend(
+                plugin.compare(baselines[plugin], snapshots[plugin])
+            )
+
+        if all_failures:
+            self.fail(
+                "PHASE 6: IO comparison failures:\n  "
+                + "\n  ".join(all_failures)
+            )
+        log.info(
+            "PHASE 6: All IO parameters match baseline; "
+            "all lockdown restrictions confirmed"
+        )
+
+        # ---------------------------------------------------------------- #
+        #  Phases 7-8: HTX block device stress (opt-in)                    #
+        # ---------------------------------------------------------------- #
+        if self._htx_util is None or not self._htx_util.is_configured():
+            log.info(
+                "PHASE 7: htx_rpm_link not set — skipping HTX phases"
+            )
+            return
+
+        log.info("PHASE 7: Installing HTX on host")
+        self._htx_util.install()
+
+        block_devs = self._htx_block_devices()
+        if not block_devs:
+            log.warning(
+                "PHASE 7: No block devices resolved for HTX — skipping"
+            )
+            return
+
+        log.info(
+            "PHASE 7: Starting HTX mdt.hd on block devices: %s",
+            ', '.join(block_devs),
+        )
+        self._htx_util.start(block_devs)
+
+        log.info("PHASE 8: Polling htxerr for %d seconds",
+                 self._htx_util._run_time)
+        htx_failures = self._htx_util.wait_and_check()
+
+        self._htx_util.stop()
+
+        if htx_failures:
+            self.fail(
+                "PHASE 8: HTX mdt.hd errors detected:\n  "
+                + "\n  ".join(htx_failures)
+            )
+        log.info("PHASE 8: HTX run completed cleanly — no errors in htxerr")
+
+    def _htx_block_devices(self):
+        '''
+        Return bare block device names to activate in HTX (e.g. ['nvme0n1']).
+        Base class returns [] — HTX phases are skipped for non-block-device
+        subclasses. Block-device subclasses (e.g. NVMeSecureBootIO) must
+        override this method to provide the actual device list.
+        '''
+        return []
+
+
+# ======================================================================= #
+#  Runnable Test Classes                                                   #
+# ======================================================================= #
+
+class NVMeSecureBootIO(OpTestSecureBootIO):
+    '''
+    Validates NVMe device integrity across the Secure Boot enable transition,
+    then optionally runs HTX mdt.hd on the NVMe namespaces for 30 minutes.
+
+    HTX (Phases 7-8) is triggered only when htx_rpm_link is present in the
+    cfg file.  htx_run_time defaults to 1800 s (30 min) when not specified.
+
+    Run with:
+      op-test --run testcases.OpTestSecureBootIO.NVMeSecureBootIO
+    '''
+
+    def setUp(self):
+        super().setUp()
+        conf = OpTestConfiguration.conf
+
+        # ---- NVMe plugin ------------------------------------------------ #
+        raw_filter = getattr(conf.args, 'nvme_devices', None)
+        device_filter = set()
+        if raw_filter:
+            for token in raw_filter.split(','):
+                token = token.strip().replace('/dev/', '')
+                if token:
+                    device_filter.add(token)
+        self.io_plugins = [NVMePlugin(self.c, device_filter)]
+
+        # ---- HTX utility (block devices only) --------------------------- #
+        # Reads htx_rpm_link and htx_run_time directly from conf.args so
+        # they map naturally from the [op-test] section of the cfg file.
+        # No CLI-only argument registration needed in OpTestConfiguration.
+        rpm_link = getattr(conf.args, 'htx_rpm_link', None)
+        run_time = getattr(conf.args, 'htx_run_time', 1800)
+
+        distro_version = self.util.get_distro_version()
+
+        self._htx_util = OpTestHTXUtil(
+            console       = self.c,
+            ssh_host      = self.cv_HOST,
+            distro_name   = self.distro,
+            distro_version= distro_version,
+            rpm_link      = rpm_link,
+            run_time      = run_time,
+        )
+
+    def _htx_block_devices(self):
+        '''
+        Derive bare NVMe namespace names (nvme0n1, nvme1n1, …) from the
+        nvme_devices cfg entry.  Falls back to auto-discovery when
+        nvme_devices is not set.
+
+        Uses the first namespace (n1) per controller — consistent with
+        queue_attrs logic in NVMePlugin.collect().
+        '''
+        raw = getattr(OpTestConfiguration.conf.args, 'nvme_devices', None)
+        if raw:
+            devs = []
+            for token in raw.split(','):
+                ctrl = token.strip().replace('/dev/', '')
+                if ctrl:
+                    # /dev/nvme0 → nvme0n1
+                    devs.append(ctrl + 'n1')
+            return devs
+
+        # Auto-discover: collect nvmeXn1 namespaces from nvme list
+        out = self.c.run_command_ignore_fail('nvme list')
+        seen = []
+        for line in out:
+            if not line.startswith('/dev/nvme'):
+                continue
+            ns = line.split()[0].replace('/dev/', '')   # e.g. nvme0n1
+            if ns not in seen:
+                seen.append(ns)
+        return seen
+
+    def runTest(self):
+        super().runTest()
+
+
+def SecureBootIO_suite():
+    '''Return a TestSuite containing all OpTestSecureBootIO test classes.'''
+    s = unittest.TestSuite()
+    s.addTest(NVMeSecureBootIO())
+    return s


### PR DESCRIPTION
Adds an op-test case to verify that NVMe I/O devices remain visible and unchanged after Secure Boot is enabled on IBM Power LPAR systems. It collects NVMe device details before enabling Secure Boot, enables Secure Boot through the existing HMC and OS flow, then collects the same details again after reboot. The test compares both snapshots to confirm that controllers, namespaces, queue attributes, and driver state are preserved. It also checks that Secure Boot lockdown is active and that restricted NVMe register access is blocked as expected.

Short PR-friendly version:

This change adds a new Secure Boot I/O validation test for NVMe devices on IBM Power LPARs. The test captures NVMe state before and after enabling Secure Boot, verifies that device configuration remains consistent across the transition, and confirms that lockdown protections are enforced after boot.