### PR TITLE
OpTestKernelDump: Enable Fedora support for validating Kdump

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -190,8 +190,9 @@ class OptestKernelDump(unittest.TestCase):
         self.util = self.cv_SYSTEM.util
         self.op_test_util = OpTestUtil(conf)
         self.distro = self.op_test_util.distro_name()
-        self.version = self.op_test_util.get_distro_version().split(".")[0]
-        self.minor_version = self.op_test_util.get_distro_version().split(".")[1]
+        _ver_parts = self.op_test_util.get_distro_version().split(".")
+        self.version = _ver_parts[0]
+        self.minor_version = _ver_parts[1] if len(_ver_parts) > 1 else "0"
         self.pdbg = conf.args.pdbg
         self.basedir = conf.basedir
         # Use SSH for pre-crash commands, console only needed after crash for login
@@ -240,8 +241,11 @@ class OptestKernelDump(unittest.TestCase):
         elif 'SLES' in res[0] or 'SLES' in res[1]:
             self.distro = 'sles'
             self.c.run_command("cp /etc/sysconfig/kdump /etc/sysconfig/kdump_bck")
+        elif 'Fedora' in res[0] or 'Fedora' in res[1]:
+            self.distro = 'fedora'
+            self.c.run_command("cp /etc/kdump.conf /etc/kdump.conf_bck")
         else:
-            raise self.skipTest("Test currently supported only on ubuntu, sles and rhel")
+            raise self.skipTest("Test currently supported only on ubuntu, sles, rhel and fedora")
 
     def wait_for_ssh_after_reboot(self, timeout=600, initial_delay=30):
         '''
@@ -328,6 +332,8 @@ class OptestKernelDump(unittest.TestCase):
         self.c.run_command("rm -f %s" % self.rsa_path)
         if self.distro == "rhel":
             cmd = "yum -y install sshpass"
+        elif self.distro == "fedora":
+            cmd = "dnf install -y sshpass"
         elif self.distro == "sles":
             cmd = "zypper install -y sshpass"
         else:
@@ -448,7 +454,7 @@ class OptestKernelDump(unittest.TestCase):
         if boot_type == BootType.INVALID:
             self.fail("System did not boot after crash - SSH unavailable. Check console logs for errors (OOM, panic, etc.)")
         
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.cv_HOST.host_run_command("cp /etc/kdump.conf_bck /etc/kdump.conf; systemctl restart kdump.service", timeout=120)
         if self.distro == "sles":
             self.cv_HOST.host_run_command("cp /etc/sysconfig/kdump_bck /etc/sysconfig/kdump; systemctl restart kdump.service", timeout=120)
@@ -1113,7 +1119,7 @@ class KernelCrash_FadumpEnable(OptestKernelDump):
         Pre setup for fadump configuration
         '''
         self.cv_SYSTEM.set_state(OpSystemState.OS)
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             try:
                 self.c.run_command("rm -rf ServiceReport; git clone https://github.com/linux-ras/ServiceReport; cd ServiceReport;"
                                    "python ./servicereport --plugins fadump package --repair", timeout=240)
@@ -1166,7 +1172,7 @@ class KernelCrash_FadumpEnable(OptestKernelDump):
             raise self.skipTest("fadump is disabled")
         if self.distro == "ubuntu":
             self.cv_HOST.host_check_command("kdump")
-        elif self.distro == "rhel":
+        elif self.distro in ("rhel", "fedora"):
             self.cv_HOST.host_check_command("kdumpctl")
         elif self.distro == "sles":
             self.cv_HOST.host_check_command("kdumptool")
@@ -1198,7 +1204,7 @@ class KernelCrash_OnlyKdumpEnable(OptestKernelDump):
 
         if self.is_fadump_param_enabled():
             log.info("fadump is enabled. Next, remove fadump=on")
-            if self.distro == "rhel":
+            if self.distro in ("rhel", "fedora"):
                 obj = OpTestInstallUtil.InstallUtil()
                 if not obj.update_kernel_cmdline(self.distro, remove_args="fadump=on",
                                                  reboot=True, reboot_cmd=True):
@@ -1228,7 +1234,7 @@ class KernelCrash_OnlyKdumpEnable(OptestKernelDump):
 
         if self.distro == "ubuntu":
             self.cv_HOST.host_check_command("kdump")
-        elif self.distro == "rhel":
+        elif self.distro in ("rhel", "fedora"):
             self.cv_HOST.host_check_command("kdumpctl")
             try:
                 self.c.run_command("rm -rf ServiceReport; git clone https://github.com/linux-ras/ServiceReport; cd ServiceReport;"
@@ -1284,7 +1290,7 @@ class KernelCrash_DisableAll(OptestKernelDump):
                 "fadump=on added in kernel param, please remove and re-try")
         if self.distro == "ubuntu":
             self.cv_HOST.host_check_command("kdump")
-        elif self.distro == "rhel":
+        elif self.distro in ("rhel", "fedora"):
             self.cv_HOST.host_check_command("kdumpctl")
         elif self.distro == "sles":
             self.cv_HOST.host_check_command("kdumptool")
@@ -1358,7 +1364,7 @@ class KernelCrash_KdumpSSH(OptestKernelDump):
 
     def setup_ssh(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.c.run_command("sed -i -e '/^nfs/ s/^#*/#/' /etc/kdump.conf; sync")
             self.c.run_command("sed -i '/ssh user@my.server.com/c\ssh root@%s' /etc/kdump.conf; sync" % self.dump_server_ip)
             self.c.run_command("sed -i '/sshkey \/root\/.ssh\/kdump_id_rsa/c\sshkey %s' /etc/kdump.conf; sync" % self.rsa_path)
@@ -1417,10 +1423,10 @@ class KernelCrash_KdumpNFS(OptestKernelDump):
 
     def setup_nfs(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.c.run_command("sed -i '/ssh root@%s/c\#ssh user@my.server.com' /etc/kdump.conf; sync" % self.dump_server_ip)
             self.c.run_command("sed -i '/sshkey %s/c\#sshkey \/root\/.ssh\/kdump_id_rsa' /etc/kdump.conf; sync" % self.rsa_path)
-            self.c.run_command("yum -y install nfs-utils", timeout=180)
+            self.c.run_command("dnf install -y nfs-utils || yum -y install nfs-utils", timeout=180)
             self.c.run_command("service nfs-server start")
             self.c.run_command("sed -i -e '/^nfs/ s/^#*/#/' /etc/kdump.conf;"
                                "echo 'nfs %s:%s' >> /etc/kdump.conf; sync" % (self.dump_location, self.dump_path))
@@ -1476,7 +1482,7 @@ class KernelCrash_KdumpSAN(OptestKernelDump):
 
     def setup_san(self):
         self.cv_SYSTEM.goto_state(OpSystemState.OS)
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.cv_HOST.host_run_command("sfdisk --delete %s" % self.dev_path)
             self.cv_HOST.host_run_command("echo , | sfdisk --force %s" % self.dev_path, timeout=120)
             try: self.c.run_command("umount %s1" % self.dev_path)
@@ -1574,6 +1580,8 @@ class KernelCrash_KdumpWorkLoad(OptestKernelDump):
         self.setup_test()
         if self.distro == "rhel":
             cmd = "yum -y install make gcc wget"
+        elif self.distro == "fedora":
+            cmd = "dnf install -y make gcc wget"
         elif self.distro == "ubuntu":
             cmd = "apt-get install -y make gcc wget"
         else:
@@ -1615,6 +1623,8 @@ class KernelCrash_PerfTest(OptestKernelDump):
             try:
                 if self.distro == "rhel":
                     self.c.run_command("yum -y install perf", timeout=300)
+                elif self.distro == "fedora":
+                    self.c.run_command("dnf install -y perf", timeout=300)
                 elif self.distro == "sles":
                     self.c.run_command("zypper install -y perf", timeout=300)
                 log.info("perf package installed successfully")
@@ -1884,8 +1894,8 @@ class KernelCrash_KdumpMultiThreadCheck(OptestKernelDump):
         return int(match.group(1))
 
     def runTest(self):
-        if self.distro == "sles":
-            self.skipTest("skipping the testcase for now.. Need to figure out a way to verify multithreading in sles")
+        if self.distro in ("sles", "fedora"):
+            self.skipTest("skipping the testcase for now.. Need to figure out a way to verify multithreading in sles/fedora")
         nr_cpus = self.get_nr_cpus()
         log.info(f"Current nr_cpus: {nr_cpus}")
         if nr_cpus != 16:
@@ -2061,6 +2071,8 @@ class KernelCrash_KdumpPMEM(OptestKernelDump):
         self.setup_test()
         if self.distro == "rhel":
             cmd = "yum -y install ndctl"
+        elif self.distro == "fedora":
+            cmd = "dnf install -y ndctl"
         elif self.distro == "sles":
             cmd = "zypper install -y ndctl"
         try:
@@ -2085,7 +2097,7 @@ class KernelCrash_KdumpPMEM(OptestKernelDump):
         self.c.run_command("mount -o dax /dev/pmem%s /pmem%s" % (self.pmem_id, self.pmem_id))
         self.c.run_command("echo '/dev/pmem%s /pmem%s                   xfs     defaults        0 0' >> /etc/fstab"
                            % (self.pmem_id, self.pmem_id))
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.c.run_command("echo 'add_drivers+=\"papr_scm\"' > /etc/dracut.conf.d/99-pmem-workaround.conf")
             self.c.run_command("sed -i 's/path \/var\/crash/path \/pmem%s/' /etc/kdump.conf; sync" % self.pmem_id)
             try:
@@ -2104,7 +2116,7 @@ class KernelCrash_KdumpPMEM(OptestKernelDump):
         self.c.run_command("umount /pmem%s" % self.pmem_id)
         self.c.run_command("ndctl destroy-namespace all -f")
         self.c.run_command("sed -i '$d' \/etc\/fstab")
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.c.run_command("sed -i 's/path \/pmem%s/path \/var\/crash/' /etc/kdump.conf; sync" % self.pmem_id)
         if self.distro == "sles":
             self.c.run_command('sed -i \'/^KDUMP_SAVEDIR=/c\KDUMP_SAVEDIR=\"/var/crash\"\' /etc/sysconfig/kdump;')
@@ -2216,7 +2228,7 @@ class KernelCrash_FadumpJunkValue(OptestKernelDump):
     """
     def runTest(self):
 
-        if self.distro.lower() not in ["sles", "rhel"]:
+        if self.distro.lower() not in ["sles", "rhel", "fedora"]:
             self.skipTest(f"Fadump testing not supported on {self.distro}")
         if self.distro.lower() == "sles" and int(self.version) < 16:
             self.skipTest(f"Not supported on SLES {self.version}")
@@ -2247,9 +2259,9 @@ class KernelCrash_FadumpJunkValue(OptestKernelDump):
 
         log.info("Triggering crash with junk fadump=xyz ...")
         boot_type = self.kernel_crash()
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.verify_dump_file(boot_type)
-            log.info("In Rhel, dump has got captured as kdump will be enabled")
+            log.info("In Rhel/Fedora, dump has got captured as kdump will be enabled")
         else:
             try:
                 self.verify_dump_file(boot_type)
@@ -2266,6 +2278,8 @@ class KernelCmdlineParamTest(OptestKernelDump):
     Function to add extra boot args to fadump kernel and check.
     '''
     def runTest(self):
+        if self.distro not in ("sles", "rhel"):
+            self.skipTest(f"KernelCmdlineParamTest not supported on {self.distro} — requires /etc/sysconfig/kdump")
         conf = OpTestConfiguration.conf
         # Step 1: Read current FADUMP_COMMANDLINE_APPEND
         try:
@@ -2316,7 +2330,7 @@ class KernelCrash_FadumpOffValue(OptestKernelDump):
     """
     def runTest(self):
 
-        if self.distro.lower() not in ["sles", "rhel"]:
+        if self.distro.lower() not in ["sles", "rhel", "fedora"]:
             self.skipTest(f"Fadump testing not supported on {self.distro}")
         if self.distro.lower() == "sles" and int(self.version) < 16:
             self.skipTest(f"Not supported on SLES {self.version}")
@@ -2346,9 +2360,9 @@ class KernelCrash_FadumpOffValue(OptestKernelDump):
 
         log.info("Triggering crash with fadump=off ...")
         boot_type = self.kernel_crash()
-        if self.distro == "rhel":
+        if self.distro in ("rhel", "fedora"):
             self.verify_dump_file(boot_type)
-            log.info("In Rhel, dump has got captured as kdump will be enabled")
+            log.info("In Rhel/Fedora, dump has got captured as kdump will be enabled")
         else:
             try:
                 self.verify_dump_file(boot_type)
@@ -2365,8 +2379,8 @@ class KernelCrash_FadumpMultiThreadCheck(OptestKernelDump):
     """
     def runTest(self):
         # Step 1: Read nr_cpus from /etc/sysconfig/kdump
-        if self.distro == "sles":
-            self.skipTest("skipping the testcase for now.. Need to figure out a way to verify multithreading in sles")
+        if self.distro in ("sles", "fedora"):
+            self.skipTest("skipping the testcase for now.. Need to figure out a way to verify multithreading in sles/fedora")
         syscfg = self.c.run_command("grep ^FADUMP_COMMANDLINE_APPEND /etc/sysconfig/kdump")
         syscfg_str = "\n".join(syscfg).strip()
         match = re.search(r"nr_cpus=(\d+)", syscfg_str)
@@ -2434,9 +2448,9 @@ class OpTestKdumpKernelSwitch(OptestKernelDump):
     def runTest(self):
         running_kernel = self.c.run_command("uname -r")[0].strip()
         kernels = []
-        if self.distro == "sles":
+        if self.distro in ("sles", "fedora"):
             self.skipTest(
-                "skipping the testcase for now.. Need to figure out a way to verify kdump kernel version in sles")
+                "skipping the testcase for now.. Need to figure out a way to verify kdump kernel version in sles/fedora")
         elif ("rhel" in self.distro or
                 "redhat" in self.distro):
             kernels = self._get_installed_kernels_rhel()
@@ -2662,7 +2676,7 @@ class OpTestWatchdog(OptestKernelDump):
         self.kdumpNFS = KernelCrash_KdumpNFS()
         self.kdumpNFS.setUp()
         if self.check_module_support():
-            if self.distro == "rhel":
+            if self.distro in ("rhel", "fedora"):
                 self.cv_HOST.host_check_command("kdumpctl")
                 obj = OpTestInstallUtil.InstallUtil()
                 if not obj.update_kernel_cmdline(self.distro, args="crashkernel=2G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G",
@@ -2698,7 +2712,7 @@ class OpTestWatchdog(OptestKernelDump):
         self.kdumpSAN = KernelCrash_KdumpSAN()
         self.kdumpSAN.setUp()
         if self.check_module_support():
-            if self.distro == "rhel":
+            if self.distro in ("rhel", "fedora"):
                 self.cv_HOST.host_check_command("kdumpctl")
                 obj = OpTestInstallUtil.InstallUtil()
                 if not obj.update_kernel_cmdline(self.distro, args="crashkernel=2G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G",
@@ -2727,7 +2741,7 @@ class OpTestWatchdog(OptestKernelDump):
         crash dump on local "/var/crash" directory.
         '''
         if self.check_module_support():
-            if self.distro == "rhel":
+            if self.distro in ("rhel", "fedora"):
                 self.cv_HOST.host_check_command("kdumpctl")
                 obj = OpTestInstallUtil.InstallUtil()
                 if not obj.update_kernel_cmdline(self.distro, args="crashkernel=2G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G",
@@ -2793,6 +2807,8 @@ class MeasureMakedumpTime(OptestKernelDump):
                 self.c.run_command("zypper install -y gcc make wget tar", timeout=600)
             elif self.distro == "rhel":
                 self.c.run_command("yum -y install gcc make wget tar", timeout=600)
+            elif self.distro == "fedora":
+                self.c.run_command("dnf install -y gcc make wget tar", timeout=600)
         except CommandFailed as cf:
             log.warning("fail to install pre-requisites: %s", cf.output)
         self.c.run_command(
@@ -2878,7 +2894,7 @@ class MeasureMakedumpTime(OptestKernelDump):
             # Find latest crash directory
             crash_dir = self.c.run_command("ls -td /var/crash/* | head -1")[0].strip()
 
-            if self.distro == "rhel":
+            if self.distro in ("rhel", "fedora"):
                 logs = self.c.run_command(
                     f"cat {crash_dir}/kexec-dmesg.log | grep kdump"
                 )
@@ -2978,7 +2994,7 @@ class TestTimezoneKdump(OptestKernelDump):
         if self.distro == 'sles':
             self.c.run_command("mkdumprd -f")
             self.c.run_command("systemctl restart kdump.service")
-        elif self.distro == 'rhel':
+        elif self.distro in ('rhel', 'fedora'):
             try:
                 self.c.run_command("kdumpctl rebuild")
                 self.c.run_command("kdumpctl restart", timeout=120)


### PR DESCRIPTION
### Extend kdump/fadump test coverage to Fedora Linux. Fedora uses the same /etc/kdump.conf and kdumpctl tooling as RHEL but requires dnf instead of yum for package management.

Changes:
- Detect Fedora in setUp() via /etc/os-release and back up /etc/kdump.conf
- Use dnf for package installs: sshpass, nfs-utils, ndctl, perf, make/gcc/wget, stress-ng build deps
- Extend all rhel-only distro guards to ("rhel", "fedora") for:
  - verify_dump_file: restore kdump.conf_bck on post-crash cleanup
  - KernelCrash_FadumpEnable: setup_fadump() and kdumpctl check
  - KernelCrash_OnlyKdumpEnable: fadump removal and ServiceReport setup
  - KernelCrash_DisableAll: kdumpctl check
  - KernelCrash_KdumpSSH/NFS/SAN: /etc/kdump.conf configuration
  - KernelCrash_KdumpPMEM: dracut config and kdump.conf path handling
  - KernelCrash_FadumpJunkValue/OffValue: include Fedora in allowlist and verify dump capture (kdump remains active like RHEL)
  - OpTestWatchdog: crashkernel cmdline update and kdumpctl check
  - MeasureMakedumpTime: prereq install and kexec-dmesg.log parsing
  - TestTimezoneKdump: kdumpctl rebuild/restart
- Skip KernelCrash_KdumpMultiThreadCheck, KernelCrash_FadumpMultiThreadCheck and OpTestKdumpKernelSwitch on Fedora as they rely on /etc/sysconfig/kdump keys not present on Fedora
- Add skip guard to KernelCmdlineParamTest which reads FADUMP_COMMANDLINE_APPEND from /etc/sysconfig/kdump (SLES/RHEL only)

Signed-off-by: Misbah Anjum N <misanjumn@ibm.com>