### PR TITLE
OpTestKernelDump: increase module load/unload iterations to 50

### DIFF
--- a/testcases/OpTestKernelDump.py
+++ b/testcases/OpTestKernelDump.py
@@ -2609,7 +2609,7 @@ class OpTestWatchdog(OptestKernelDump):
         to the count as per user input
         '''
         conf = OpTestConfiguration.conf
-        self.count = conf.args.count or "10"
+        self.count = conf.args.count or "50"
         if self.check_module_support:
             for _ in range(int(self.count)):
                 try:


### PR DESCRIPTION
load/unload iteration count in check_module_load_unload() 
is raised from 10 to 50 for the pseries_wdt watchdog module.

Signed-off-by: Sneh Shikha Yadav <syadav@linux.ibm.com>